### PR TITLE
Feat/strategy register request #27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,78 @@ plugins {
     id "org.sonarqube" version "5.1.0.4882"
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.threestar'
 version = '0.0.1-SNAPSHOT'
+
+jacoco {
+    toolVersion = '0.8.12'
+}
+
+test {
+    jacoco {
+        destinationFile = layout.buildDirectory.file("jacoco/jacoco.exec").get().asFile
+    }
+
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter'
+    }
+
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+
+        html.outputLocation.set(layout.buildDirectory.dir("jacoco/html"))
+        xml.outputLocation.set(layout.buildDirectory.file("jacoco/jacoco.xml"))
+    }
+
+    // 이 설정을 열어주면 Code Coverage가 일정 이상이어야 Build됨
+    // finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.30
+            }
+        }
+
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 300
+            }
+
+            excludes = [
+                    '*.test.*'
+            ]
+        }
+    }
+}
 
 java {
     toolchain {
@@ -57,6 +125,16 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
+
+sonarqube {
+    properties {
+        property "sonar.scm.disabled", "true"
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java, **/*Config.java' +
+                '**/*Response.java, **/*Exception.java, **/security/**, **/support/**, **/Q*.java, **/dto/**, **/entity/**,'
+    }
+}
+

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -1,0 +1,22 @@
+package com.investmetic.domain.strategy.controller;
+
+import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
+import com.investmetic.domain.strategy.service.StrategyService;
+import com.investmetic.global.exception.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/strategies")
+@RequiredArgsConstructor
+public class StrategyController {
+    private final StrategyService strategyService;
+
+    @GetMapping("/register")
+    public ResponseEntity<BaseResponse<RegisterInfoResponseDto>> loadStrategyRegistrationInfo() {
+        return strategyService.loadStrategyRegistrationInfo();
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -17,6 +17,6 @@ public class StrategyController {
 
     @GetMapping("/register")
     public ResponseEntity<BaseResponse<RegisterInfoResponseDto>> loadStrategyRegistrationInfo() {
-        return strategyService.loadStrategyRegistrationInfo();
+        return BaseResponse.success(strategyService.loadStrategyRegistrationInfo());
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/StockTypeDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/StockTypeDto.java
@@ -1,0 +1,29 @@
+package com.investmetic.domain.strategy.dto;
+
+import com.investmetic.domain.strategy.model.entity.StockType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StockTypeDto {
+    private Long stockTypeId;
+    private String stockTypeName;
+    private String stockIconUrl;
+
+
+    @Builder
+    public StockTypeDto(Long stockTypeId, String stockTypeName, String stockIconUrl) {
+        this.stockTypeId = stockTypeId;
+        this.stockTypeName = stockTypeName;
+        this.stockIconUrl = stockIconUrl;
+    }
+
+    // Entity -> DTO 변환
+    public static StockTypeDto from(StockType stockType) {
+        return StockTypeDto.builder()
+                .stockTypeId(stockType.getStockTypeId())
+                .stockTypeName(stockType.getStockTypeName())
+                .stockIconUrl(stockType.getStockTypeIconURL())
+                .build();
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/TradeTypeDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/TradeTypeDto.java
@@ -12,14 +12,14 @@ import lombok.NoArgsConstructor;
 public class TradeTypeDto {
     private Long tradeTypeId;
     private String tradeTypeName;
-    private String tradeIconUrl;
+    private String tradeTypeIconURL;
 
     // Entity -> DTO
     public static TradeTypeDto fromEntity(TradeType tradeType) {
         return new TradeTypeDto(
                 tradeType.getTradeTypeId(),
                 tradeType.getTradeTypeName(),
-                tradeType.getTradeIconURL()
+                tradeType.getTradeTypeIconURL()
         );
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/TradeTypeDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/TradeTypeDto.java
@@ -1,0 +1,25 @@
+package com.investmetic.domain.strategy.dto;
+
+import com.investmetic.domain.strategy.model.entity.TradeType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TradeTypeDto {
+    private Long tradeTypeId;
+    private String tradeTypeName;
+    private String tradeIconUrl;
+
+    // Entity -> DTO
+    public static TradeTypeDto fromEntity(TradeType tradeType) {
+        return new TradeTypeDto(
+                tradeType.getTradeTypeId(),
+                tradeType.getTradeTypeName(),
+                tradeType.getTradeIconURL()
+        );
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/request/TradeTypeRequestDTO.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/request/TradeTypeRequestDTO.java
@@ -9,13 +9,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TradeTypeRequestDTO {
     private String tradeTypeName;
-    private String tradeIconURL;
+    private String tradeTypeIconURL;
     private int size;
 
     @Builder
-    public TradeTypeRequestDTO(String tradeTypeName, String tradeIconURL, int size) {
+    public TradeTypeRequestDTO(String tradeTypeName, String tradeTypeIconURL, int size) {
         this.tradeTypeName = tradeTypeName;
-        this.tradeIconURL = tradeIconURL;
+        this.tradeTypeIconURL = tradeTypeIconURL;
         this.size = size;
     }
 
@@ -24,7 +24,7 @@ public class TradeTypeRequestDTO {
         return TradeType.builder()
                 .tradeTypeName(tradeTypeName)
                 .activateState(true) // 기본값으로 활성 상태 설정
-                .tradeIconURL(tradeIconURL)
+                .tradeTypeIconURL(tradeTypeIconURL)
                 .build();
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/request/TradeTypeRequestDTO.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/request/TradeTypeRequestDTO.java
@@ -1,7 +1,6 @@
 package com.investmetic.domain.strategy.dto.request;
 
 import com.investmetic.domain.strategy.model.entity.TradeType;
-import jakarta.persistence.Column;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,24 +9,22 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TradeTypeRequestDTO {
     private String tradeTypeName;
-
-    @Column(length = 1000)
-    private String tradeTypeIconURL;
-    int size;
+    private String tradeIconURL;
+    private int size;
 
     @Builder
-    public TradeTypeRequestDTO(String tradeName, Boolean activateState, String tradeTypeIconURL, int size) {
-        this.tradeTypeName = tradeName;
-        this.tradeTypeIconURL = tradeTypeIconURL;
+    public TradeTypeRequestDTO(String tradeTypeName, String tradeIconURL, int size) {
+        this.tradeTypeName = tradeTypeName;
+        this.tradeIconURL = tradeIconURL;
         this.size = size;
     }
 
+    // DTO -> Entity 변환 메서드
     public TradeType toEntity() {
         return TradeType.builder()
                 .tradeTypeName(tradeTypeName)
-                .activateState(true)
-                .tradeIconURL(tradeTypeIconURL)
+                .activateState(true) // 기본값으로 활성 상태 설정
+                .tradeIconURL(tradeIconURL)
                 .build();
     }
-
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/RegisterInfoResponseDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/RegisterInfoResponseDto.java
@@ -1,0 +1,22 @@
+package com.investmetic.domain.strategy.dto.response;
+
+import com.investmetic.domain.strategy.dto.StockTypeDto;
+import com.investmetic.domain.strategy.dto.TradeTypeDto;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RegisterInfoResponseDto {
+    private List<StockTypeDto> stockTypes;
+    private List<TradeTypeDto> tradeTypes;
+
+    @Builder
+    public RegisterInfoResponseDto(List<StockTypeDto> stockTypes, List<TradeTypeDto> tradeTypes) {
+        this.stockTypes = stockTypes;
+        this.tradeTypes = tradeTypes;
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/TradeTypeResponseDTO.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/TradeTypeResponseDTO.java
@@ -28,7 +28,7 @@ public class TradeTypeResponseDTO {
         return TradeTypeResponseDTO.builder()
                 .tradeTypeId(tradeType.getTradeTypeId())
                 .tradeName(tradeType.getTradeTypeName())
-                .tradeIconURL(tradeType.getTradeIconURL())
+                .tradeIconURL(tradeType.getTradeTypeIconURL())
                 .activateState(tradeType.getActivateState())
                 .build();
     }

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/StockType.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/StockType.java
@@ -24,6 +24,7 @@ public class StockType extends BaseEntity {
     private Long stockTypeId;
 
     private String stockTypeName; // 종목명
+
     private Boolean activateState; // 종목 활성 상태
 
     @Column(length = 1000)

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/TradeType.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/TradeType.java
@@ -21,10 +21,10 @@ public class TradeType extends BaseEntity {
     private Boolean activateState;
 
     @Column(length = 1000)
-    private String tradeIconURL;
+    private String tradeTypeIconURL;
 
-    public void changeTradeIconURL(String tradeIconURL) {
-        this.tradeIconURL = tradeIconURL;
+    public void changeTradeIconURL(String tradeTypeIconURL) {
+        this.tradeTypeIconURL = tradeTypeIconURL;
     }
 
     public void changeActivateState(boolean activateState) {

--- a/src/main/java/com/investmetic/domain/strategy/repository/StockTypeRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StockTypeRepository.java
@@ -1,11 +1,8 @@
 package com.investmetic.domain.strategy.repository;
 
 import com.investmetic.domain.strategy.model.entity.StockType;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface StockTypeRepository extends JpaRepository<StockType, Long> {
 
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/TradeTypeRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/TradeTypeRepository.java
@@ -1,6 +1,5 @@
 package com.investmetic.domain.strategy.repository;
 
-import com.investmetic.domain.strategy.dto.TradeTypeDto;
 import com.investmetic.domain.strategy.model.entity.TradeType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/investmetic/domain/strategy/repository/TradeTypeRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/TradeTypeRepository.java
@@ -1,10 +1,12 @@
 package com.investmetic.domain.strategy.repository;
 
+import com.investmetic.domain.strategy.dto.TradeTypeDto;
 import com.investmetic.domain.strategy.model.entity.TradeType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TradeTypeRepository extends JpaRepository<TradeType, Long> {
-
+    List<TradeType> findByActivateStateTrue();
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/TradeTypeRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/TradeTypeRepository.java
@@ -3,9 +3,7 @@ package com.investmetic.domain.strategy.repository;
 import com.investmetic.domain.strategy.model.entity.TradeType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface TradeTypeRepository extends JpaRepository<TradeType, Long> {
     List<TradeType> findByActivateStateTrue();
 }

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
@@ -1,0 +1,50 @@
+package com.investmetic.domain.strategy.service;
+
+import com.investmetic.domain.strategy.dto.StockTypeDto;
+import com.investmetic.domain.strategy.dto.TradeTypeDto;
+import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
+import com.investmetic.domain.strategy.repository.StockTypeRepository;
+import com.investmetic.domain.strategy.repository.TradeTypeRepository;
+import com.investmetic.global.exception.BaseResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StrategyService {
+    private final TradeTypeRepository tradeTypeRepository;
+    private final StockTypeRepository stockTypeRepository;
+
+    public ResponseEntity<BaseResponse<RegisterInfoResponseDto>> loadStrategyRegistrationInfo() {
+        List<TradeTypeDto> tradeTypesDto = getActiveTradeTypes();
+        List<StockTypeDto> stockTypesDto = getAllStockTypes();
+
+        RegisterInfoResponseDto responseDto = buildRegisterInfoResponse(tradeTypesDto, stockTypesDto);
+
+        return BaseResponse.success(responseDto);
+    }
+
+    private List<TradeTypeDto> getActiveTradeTypes() {
+        return tradeTypeRepository.findByActivateStateTrue().stream()
+                .map(TradeTypeDto::fromEntity)
+                .toList();
+    }
+
+    private List<StockTypeDto> getAllStockTypes() {
+        return stockTypeRepository.findAll().stream()
+                .map(StockTypeDto::from)
+                .toList();
+    }
+
+    private RegisterInfoResponseDto buildRegisterInfoResponse(
+            List<TradeTypeDto> tradeTypes,
+            List<StockTypeDto> stockTypes
+    ) {
+        return RegisterInfoResponseDto.builder()
+                .tradeTypes(tradeTypes)
+                .stockTypes(stockTypes)
+                .build();
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
@@ -5,10 +5,8 @@ import com.investmetic.domain.strategy.dto.TradeTypeDto;
 import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
 import com.investmetic.domain.strategy.repository.StockTypeRepository;
 import com.investmetic.domain.strategy.repository.TradeTypeRepository;
-import com.investmetic.global.exception.BaseResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,13 +15,10 @@ public class StrategyService {
     private final TradeTypeRepository tradeTypeRepository;
     private final StockTypeRepository stockTypeRepository;
 
-    public ResponseEntity<BaseResponse<RegisterInfoResponseDto>> loadStrategyRegistrationInfo() {
+    public RegisterInfoResponseDto loadStrategyRegistrationInfo() {
         List<TradeTypeDto> tradeTypesDto = getActiveTradeTypes();
         List<StockTypeDto> stockTypesDto = getAllStockTypes();
-
-        RegisterInfoResponseDto responseDto = buildRegisterInfoResponse(tradeTypesDto, stockTypesDto);
-
-        return BaseResponse.success(responseDto);
+        return buildRegisterInfoResponse(tradeTypesDto, stockTypesDto);
     }
 
     private List<TradeTypeDto> getActiveTradeTypes() {

--- a/src/main/java/com/investmetic/domain/strategy/service/TradeTypeService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/TradeTypeService.java
@@ -6,7 +6,6 @@ import com.investmetic.domain.strategy.repository.TradeTypeRepository;
 import com.investmetic.global.util.s3.FilePath;
 import com.investmetic.global.util.s3.S3FileService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,8 +16,9 @@ public class TradeTypeService {
 
     public String saveTradeType(TradeTypeRequestDTO tradeTypeRequestDTO) {
         // 클라이언트에서 입력한 파일 경로로 생성한 이미지 경로 저장
-        TradeType tradeType=tradeTypeRequestDTO.toEntity();
-        String tradeIconURL = s3FileService.getS3Path(FilePath.STRATEGY_IMAGE, tradeType.getTradeIconURL(), tradeTypeRequestDTO.getSize());
+        TradeType tradeType = tradeTypeRequestDTO.toEntity();
+        String tradeIconURL = s3FileService.getS3Path(FilePath.STRATEGY_IMAGE, tradeType.getTradeTypeIconURL(),
+                tradeTypeRequestDTO.getSize());
         tradeType.changeTradeIconURL(tradeIconURL);
         tradeTypeRepository.save(tradeType);
         return s3FileService.getPreSignedUrl(tradeIconURL);

--- a/src/main/java/com/investmetic/domain/user/repository/mypage/UserMyPageRepository.java
+++ b/src/main/java/com/investmetic/domain/user/repository/mypage/UserMyPageRepository.java
@@ -4,9 +4,7 @@ import com.investmetic.domain.user.dto.response.UserProfileDto;
 import com.investmetic.domain.user.model.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserMyPageRepository extends JpaRepository<User, Long>, UserMyPageRepositoryCustom {
 
     Optional<UserProfileDto> findByEmailUserInfo(String email);

--- a/src/test/java/com/investmetic/domain/TestEntity/TestEntityFactory.java
+++ b/src/test/java/com/investmetic/domain/TestEntity/TestEntityFactory.java
@@ -36,7 +36,7 @@ public class TestEntityFactory {
         return TradeType.builder()
                 .tradeTypeName("Test Trade")
                 .activateState(true)
-                .tradeIconURL("http://~~")
+                .tradeTypeIconURL("http://~~")
                 .build();
     }
 

--- a/src/test/java/com/investmetic/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/investmetic/domain/review/service/ReviewServiceTest.java
@@ -57,20 +57,19 @@ class ReviewServiceTest {
         testStrategy = strategyRepository.save(TestEntityFactory.createTestStrategy(testUser, testTradeType));
     }
 
+    private void addReviewWithInvalidStrategyId() {
+        reviewService.addReview(-1L, testUser.getUserId(),
+                ReviewRequestDto.builder().content("Great strategy!").starRating(5).build());
+    }
 
     @DisplayName("전략을 찾을 수 없을 때 예외 발생")
     @Test
-    public void givenInvalidStrategyId_whenAddReview_thenThrowsException() {
-        ReviewRequestDto requestDto = ReviewRequestDto.builder()
-                .content("Great strategy!")
-                .starRating(5)
-                .build();
+    void givenInvalidStrategyId_whenAddReview_thenThrowsException() {
+        assertThrows(BusinessException.class, this::addReviewWithInvalidStrategyId);
+    }
 
-        Long invalidStrategyId = -1L;
-
-        assertThrows(BusinessException.class, () ->
-                reviewService.addReview(invalidStrategyId, testUser.getUserId(), requestDto)
-        );
+    private void updateReviewWithInvalidId(ReviewRequestDto updateDto) {
+        reviewService.updateReview(testStrategy.getStrategyId(), -1L, updateDto);
     }
 
     @DisplayName("리뷰를 찾을 수 없을 때 예외 발생")
@@ -81,11 +80,7 @@ class ReviewServiceTest {
                 .starRating(4)
                 .build();
 
-        Long invalidReviewId = -1L;
-
-        assertThrows(BusinessException.class, () ->
-                reviewService.updateReview(testStrategy.getStrategyId(), invalidReviewId, updateDto)
-        );
+        assertThrows(BusinessException.class, () -> updateReviewWithInvalidId(updateDto));
     }
 
     @DisplayName("리뷰 등록 시 리뷰 개수와 평균 별점 업데이트")

--- a/src/test/java/com/investmetic/domain/strategy/StockTypeServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/StockTypeServiceTest.java
@@ -3,8 +3,6 @@ package com.investmetic.domain.strategy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.investmetic.domain.strategy.dto.request.StockTypeRequestDTO;
-import com.investmetic.domain.strategy.model.entity.StockType;
-
 import com.investmetic.domain.strategy.service.StockTypeService;
 import com.investmetic.global.util.s3.S3FileService;
 import java.util.ArrayList;
@@ -39,7 +37,7 @@ class StockTypeServiceTest {
 
     @Test
     @DisplayName("종목 등록 테스트")
-    public void registerTradeType() {
+    void registerTradeType() {
         StockTypeRequestDTO stockType = stockTypeRequestList.get(0);
         String savedStockType = stockTypeService.saveStockType(stockType);
         assertThat(savedStockType).isNotNull();

--- a/src/test/java/com/investmetic/domain/strategy/TradeTypeServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/TradeTypeServiceTest.java
@@ -1,17 +1,15 @@
 package com.investmetic.domain.strategy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.investmetic.domain.strategy.dto.request.TradeTypeRequestDTO;
-import com.investmetic.domain.strategy.model.entity.TradeType;
 import com.investmetic.domain.strategy.service.TradeTypeService;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.ArrayList;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class TradeTypeServiceTest {

--- a/src/test/java/com/investmetic/domain/strategy/TradeTypeServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/TradeTypeServiceTest.java
@@ -20,12 +20,12 @@ class TradeTypeServiceTest {
 
     @BeforeEach
     void setUp() {
-        tradeTypeRequestDtoList = new ArrayList<TradeTypeRequestDTO>();
+        tradeTypeRequestDtoList = new ArrayList<>();
 
         for (int i = 1; i <= 5; i++) {
             TradeTypeRequestDTO tradetype = TradeTypeRequestDTO.builder()
                     .tradeTypeName("Sample_Trade" + i)
-                    .tradeIconURL(String.format("/icons/sample-icon%d.png", i))
+                    .tradeTypeIconURL(String.format("/icons/sample-icon%d.png", i))
                     .size(1200)
                     .build();
 

--- a/src/test/java/com/investmetic/domain/strategy/TradeTypeServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/TradeTypeServiceTest.java
@@ -26,8 +26,8 @@ class TradeTypeServiceTest {
 
         for (int i = 1; i <= 5; i++) {
             TradeTypeRequestDTO tradetype = TradeTypeRequestDTO.builder()
-                    .tradeName("Sample_Trade" + i)
-                    .tradeTypeIconURL(String.format("/icons/sample-icon%d.png", i))
+                    .tradeTypeName("Sample_Trade" + i)
+                    .tradeIconURL(String.format("/icons/sample-icon%d.png", i))
                     .size(1200)
                     .build();
 

--- a/src/test/java/com/investmetic/domain/strategy/service/StrategyServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/StrategyServiceTest.java
@@ -1,0 +1,77 @@
+package com.investmetic.domain.strategy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.investmetic.domain.strategy.dto.StockTypeDto;
+import com.investmetic.domain.strategy.dto.TradeTypeDto;
+import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
+import com.investmetic.domain.strategy.model.entity.StockType;
+import com.investmetic.domain.strategy.model.entity.TradeType;
+import com.investmetic.domain.strategy.repository.StockTypeRepository;
+import com.investmetic.domain.strategy.repository.TradeTypeRepository;
+import com.investmetic.global.exception.BaseResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class StrategyServiceTest {
+
+    @InjectMocks
+    private StrategyService strategyService;
+
+    @Mock
+    private TradeTypeRepository tradeTypeRepository;
+
+    @Mock
+    private StockTypeRepository stockTypeRepository;
+
+    private List<TradeType> tradeTypeList;
+    private List<StockType> stockTypeList;
+
+    @BeforeEach
+    void setUp() {
+        // Mock 데이터 생성
+        tradeTypeList = List.of(
+                new TradeType(1L, "TradeType1", true, "https://example.com/TradeType1.png"),
+                new TradeType(2L, "TradeType2", true, "https://example.com/TradeType2.png")
+        );
+
+        stockTypeList = List.of(
+                new StockType(1L, "StockType1", true, "https://example.com/StockType1.png"),
+                new StockType(2L, "StockType2", true, "https://example.com/StockType2.png")
+        );
+    }
+
+    @Test
+    @DisplayName("loadStrategyRegistrationInfo - 성공적으로 TradeType과 StockType 목록을 가져오는지 테스트")
+    void loadStrategyRegistrationInfo() {
+        when(tradeTypeRepository.findByActivateStateTrue()).thenReturn(tradeTypeList);
+        when(stockTypeRepository.findAll()).thenReturn(stockTypeList);
+
+        ResponseEntity<BaseResponse<RegisterInfoResponseDto>> response = strategyService.loadStrategyRegistrationInfo();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getBody().getIsSuccess()).isTrue();
+
+        RegisterInfoResponseDto responseDto = response.getBody().getResult();
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getTradeTypes()).hasSize(2);
+        assertThat(responseDto.getStockTypes()).hasSize(2);
+
+        TradeTypeDto tradeTypeDto = responseDto.getTradeTypes().get(0);
+        assertThat(tradeTypeDto.getTradeTypeName()).isEqualTo("TradeType1");
+        assertThat(tradeTypeDto.getTradeIconUrl()).isEqualTo("https://example.com/TradeType1.png");
+
+        StockTypeDto stockTypeDto = responseDto.getStockTypes().get(0);
+        assertThat(stockTypeDto.getStockTypeName()).isEqualTo("StockType1");
+        assertThat(stockTypeDto.getStockIconUrl()).isEqualTo("https://example.com/StockType1.png");
+    }
+}

--- a/src/test/java/com/investmetic/domain/strategy/service/StrategyServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/StrategyServiceTest.java
@@ -12,6 +12,7 @@ import com.investmetic.domain.strategy.repository.StockTypeRepository;
 import com.investmetic.domain.strategy.repository.TradeTypeRepository;
 import com.investmetic.global.exception.BaseResponse;
 import java.util.List;
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class StrategyServiceTest {
         ResponseEntity<BaseResponse<RegisterInfoResponseDto>> response = strategyService.loadStrategyRegistrationInfo();
 
         assertThat(response).isNotNull();
-        assertThat(response.getBody().getIsSuccess()).isTrue();
+        assertThat(Objects.requireNonNull(response.getBody()).getIsSuccess()).isTrue();
 
         RegisterInfoResponseDto responseDto = response.getBody().getResult();
         assertThat(responseDto).isNotNull();
@@ -68,7 +69,7 @@ class StrategyServiceTest {
 
         TradeTypeDto tradeTypeDto = responseDto.getTradeTypes().get(0);
         assertThat(tradeTypeDto.getTradeTypeName()).isEqualTo("TradeType1");
-        assertThat(tradeTypeDto.getTradeIconUrl()).isEqualTo("https://example.com/TradeType1.png");
+        assertThat(tradeTypeDto.getTradeTypeIconURL()).isEqualTo("https://example.com/TradeType1.png");
 
         StockTypeDto stockTypeDto = responseDto.getStockTypes().get(0);
         assertThat(stockTypeDto.getStockTypeName()).isEqualTo("StockType1");


### PR DESCRIPTION
## 📌 PR 개요
- 전략 등록 페이지 관련 기능 추가(GET 요청)

## #️⃣연관된 이슈

> #27 

## 📝작업 내용

- 전략 등록 페이지에서 필요한 종목 및 매매유형 값들 반환하는 기능 추가
- 코드 개선 및 불필요한 코드 제거