### PR TITLE
Feat 전략상세조회 기능구현 #14

### DIFF
--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyDetailController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyDetailController.java
@@ -2,6 +2,7 @@ package com.investmetic.domain.strategy.controller;
 
 import com.investmetic.domain.strategy.dto.response.DailyAnalysisResponse;
 import com.investmetic.domain.strategy.dto.response.MonthlyAnalysisResponse;
+import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.statistic.StrategyStatisticsResponse;
 import com.investmetic.domain.strategy.service.StrategyDetailService;
 import com.investmetic.global.common.PageResponseDto;
@@ -14,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -46,5 +48,14 @@ public class StrategyDetailController {
                 getMonthlyAnalysis(strategyId, pageable);
         return BaseResponse.success(result);
     }
+
+    @GetMapping("/detail")
+    public ResponseEntity<BaseResponse<StrategyDetailResponse>> getStrategyDetail(
+            @PathVariable Long strategyId,
+            @RequestParam Long userId) {
+        StrategyDetailResponse result = strategyDetailService.getStrategyDetail(strategyId, userId);
+        return BaseResponse.success(result);
+    }
+
 
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
@@ -1,0 +1,74 @@
+package com.investmetic.domain.strategy.dto.response;
+
+import com.investmetic.domain.strategy.model.MinimumInvestmentAmount;
+import com.investmetic.domain.strategy.model.OperationCycle;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StrategyDetailResponse {
+
+    private String strategyName;                    // 전략명
+    private List<String> stockTypeIconUrls;         // 종목 아이콘 이미지 경로 리스트
+    private String tradeIconPath;                   // 매매 유형 이미지 경로
+    private List<String> stockTypeNames;            // 투자 종목 이름 리스트
+    private String tradeTypeName;                   // 투자 종류 (자동, 반자동, 수동)
+    private OperationCycle investmentCycle;         // 투자 주기 (데이, 포지션)
+    private String strategyDescription;             // 전략 상세 소개
+    private double cumulativeProfitRate;            // 누적 수익률
+    private double maxDrawdownRate;                 // 최대 자본 인하율
+    private double averageProfitLossRate;           // 평균 손익률
+    private double profitFactor;                    // Profit Factor
+    private double winRate;                         // 승률
+    private int subscriptionCount;                  // 구독 수
+    private boolean isSubscribed;                   // 구독 여부
+    private String imageUrl;                        // 트레이더 프로필 이미지
+    private String nickname;                        // 트레이더 이름
+    private MinimumInvestmentAmount minimumInvestmentAmount;         // 최소 운용 금액
+    private long initialInvestment;                 // 투자 원금
+    private double kpRatio;                         // KP 비율
+    private double smScore;                         // SM 점수
+    private LocalDate finalProfitLossDate;          // 최종 손익 입력 일자
+    private LocalDate createdAt;                    // 전략 등록일
+
+
+    @QueryProjection
+    public StrategyDetailResponse(String strategyName, List<String> stockTypeIconUrls, String tradeIconPath,
+                                  List<String> stockTypeNames, String tradeTypeName, OperationCycle investmentCycle,
+                                  String strategyDescription, double cumulativeProfitRate, double maxDrawdownRate,
+                                  double averageProfitLossRate, double profitFactor, double winRate,
+                                  int subscriptionCount, String imageUrl, String nickname,
+                                  MinimumInvestmentAmount minimumInvestmentAmount, long initialInvestment,
+                                  double kpRatio,
+                                  double smScore, LocalDate finalProfitLossDate, LocalDate createdAt) {
+        this.strategyName = strategyName;
+        this.stockTypeIconUrls = stockTypeIconUrls;
+        this.tradeIconPath = tradeIconPath;
+        this.stockTypeNames = stockTypeNames;
+        this.tradeTypeName = tradeTypeName;
+        this.investmentCycle = investmentCycle;
+        this.strategyDescription = strategyDescription;
+        this.cumulativeProfitRate = cumulativeProfitRate;
+        this.maxDrawdownRate = maxDrawdownRate;
+        this.averageProfitLossRate = averageProfitLossRate;
+        this.profitFactor = profitFactor;
+        this.winRate = winRate;
+        this.subscriptionCount = subscriptionCount;
+        this.imageUrl = imageUrl;
+        this.nickname = nickname;
+        this.minimumInvestmentAmount = minimumInvestmentAmount;
+        this.initialInvestment = initialInvestment;
+        this.kpRatio = kpRatio;
+        this.smScore = smScore;
+        this.finalProfitLossDate = finalProfitLossDate;
+        this.createdAt = createdAt;
+    }
+
+    public void updateIsSubcried(boolean isSubscribed) {
+        this.isSubscribed = isSubscribed;
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
@@ -1,9 +1,11 @@
 package com.investmetic.domain.strategy.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.investmetic.domain.strategy.model.MinimumInvestmentAmount;
 import com.investmetic.domain.strategy.model.OperationCycle;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,11 +15,11 @@ import lombok.NoArgsConstructor;
 public class StrategyDetailResponse {
 
     private String strategyName;                    // 전략명
-    private List<String> stockTypeIconUrls;         // 종목 아이콘 이미지 경로 리스트
-    private String tradeIconPath;                   // 매매 유형 이미지 경로
+    private List<String> stockTypeIconURLs;         // 종목 아이콘 이미지 경로 리스트
+    private String tradeIconURL;                   // 매매 유형 이미지 경로
     private List<String> stockTypeNames;            // 투자 종목 이름 리스트
     private String tradeTypeName;                   // 투자 종류 (자동, 반자동, 수동)
-    private OperationCycle investmentCycle;         // 투자 주기 (데이, 포지션)
+    private OperationCycle operationCycle;         // 투자 주기 (데이, 포지션)
     private String strategyDescription;             // 전략 상세 소개
     private double cumulativeProfitRate;            // 누적 수익률
     private double maxDrawdownRate;                 // 최대 자본 인하율
@@ -28,29 +30,30 @@ public class StrategyDetailResponse {
     private boolean isSubscribed;                   // 구독 여부
     private String imageUrl;                        // 트레이더 프로필 이미지
     private String nickname;                        // 트레이더 이름
-    private MinimumInvestmentAmount minimumInvestmentAmount;         // 최소 운용 금액
+    private String minimumInvestmentAmount;         // 최소 운용 금액
     private long initialInvestment;                 // 투자 원금
     private double kpRatio;                         // KP 비율
     private double smScore;                         // SM 점수
     private LocalDate finalProfitLossDate;          // 최종 손익 입력 일자
-    private LocalDate createdAt;                    // 전략 등록일
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;                    // 전략 등록일
 
 
     @QueryProjection
-    public StrategyDetailResponse(String strategyName, List<String> stockTypeIconUrls, String tradeIconPath,
-                                  List<String> stockTypeNames, String tradeTypeName, OperationCycle investmentCycle,
+    public StrategyDetailResponse(String strategyName, List<String> stockTypeIconURLs, String tradeIconURL,
+                                  List<String> stockTypeNames, String tradeTypeName, OperationCycle operationCycle,
                                   String strategyDescription, double cumulativeProfitRate, double maxDrawdownRate,
                                   double averageProfitLossRate, double profitFactor, double winRate,
                                   int subscriptionCount, String imageUrl, String nickname,
                                   MinimumInvestmentAmount minimumInvestmentAmount, long initialInvestment,
                                   double kpRatio,
-                                  double smScore, LocalDate finalProfitLossDate, LocalDate createdAt) {
+                                  double smScore, LocalDate finalProfitLossDate, LocalDateTime createdAt) {
         this.strategyName = strategyName;
-        this.stockTypeIconUrls = stockTypeIconUrls;
-        this.tradeIconPath = tradeIconPath;
+        this.stockTypeIconURLs = stockTypeIconURLs;
+        this.tradeIconURL = tradeIconURL;
         this.stockTypeNames = stockTypeNames;
         this.tradeTypeName = tradeTypeName;
-        this.investmentCycle = investmentCycle;
+        this.operationCycle = operationCycle;
         this.strategyDescription = strategyDescription;
         this.cumulativeProfitRate = cumulativeProfitRate;
         this.maxDrawdownRate = maxDrawdownRate;
@@ -58,9 +61,10 @@ public class StrategyDetailResponse {
         this.profitFactor = profitFactor;
         this.winRate = winRate;
         this.subscriptionCount = subscriptionCount;
+        this.isSubscribed = false;
         this.imageUrl = imageUrl;
         this.nickname = nickname;
-        this.minimumInvestmentAmount = minimumInvestmentAmount;
+        this.minimumInvestmentAmount = minimumInvestmentAmount.getDescription();
         this.initialInvestment = initialInvestment;
         this.kpRatio = kpRatio;
         this.smScore = smScore;
@@ -68,7 +72,7 @@ public class StrategyDetailResponse {
         this.createdAt = createdAt;
     }
 
-    public void updateIsSubcried(boolean isSubscribed) {
+    public void updateIsSubscribed(boolean isSubscribed) {
         this.isSubscribed = isSubscribed;
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
@@ -16,7 +16,7 @@ public class StrategyDetailResponse {
 
     private String strategyName;                    // 전략명
     private List<String> stockTypeIconURLs;         // 종목 아이콘 이미지 경로 리스트
-    private String tradeIconURL;                   // 매매 유형 이미지 경로
+    private String tradeTypeIconURL;                   // 매매 유형 이미지 경로
     private List<String> stockTypeNames;            // 투자 종목 이름 리스트
     private String tradeTypeName;                   // 투자 종류 (자동, 반자동, 수동)
     private OperationCycle operationCycle;         // 투자 주기 (데이, 포지션)
@@ -40,7 +40,7 @@ public class StrategyDetailResponse {
 
 
     @QueryProjection
-    public StrategyDetailResponse(String strategyName, List<String> stockTypeIconURLs, String tradeIconURL,
+    public StrategyDetailResponse(String strategyName, List<String> stockTypeIconURLs, String tradeTypeIconURL,
                                   List<String> stockTypeNames, String tradeTypeName, OperationCycle operationCycle,
                                   String strategyDescription, double cumulativeProfitRate, double maxDrawdownRate,
                                   double averageProfitLossRate, double profitFactor, double winRate,
@@ -50,7 +50,7 @@ public class StrategyDetailResponse {
                                   double smScore, LocalDate finalProfitLossDate, LocalDateTime createdAt) {
         this.strategyName = strategyName;
         this.stockTypeIconURLs = stockTypeIconURLs;
-        this.tradeIconURL = tradeIconURL;
+        this.tradeTypeIconURL = tradeTypeIconURL;
         this.stockTypeNames = stockTypeNames;
         this.tradeTypeName = tradeTypeName;
         this.operationCycle = operationCycle;

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
@@ -28,7 +28,7 @@ public class StrategyDetailResponse {
     private double winRate;                         // 승률
     private int subscriptionCount;                  // 구독 수
     private boolean isSubscribed;                   // 구독 여부
-    private String imageUrl;                        // 트레이더 프로필 이미지
+    private String traderImgUrl;                        // 트레이더 프로필 이미지
     private String nickname;                        // 트레이더 이름
     private String minimumInvestmentAmount;         // 최소 운용 금액
     private long initialInvestment;                 // 투자 원금
@@ -44,7 +44,7 @@ public class StrategyDetailResponse {
                                   List<String> stockTypeNames, String tradeTypeName, OperationCycle operationCycle,
                                   String strategyDescription, double cumulativeProfitRate, double maxDrawdownRate,
                                   double averageProfitLossRate, double profitFactor, double winRate,
-                                  int subscriptionCount, String imageUrl, String nickname,
+                                  int subscriptionCount, String traderImgUrl, String nickname,
                                   MinimumInvestmentAmount minimumInvestmentAmount, long initialInvestment,
                                   double kpRatio,
                                   double smScore, LocalDate finalProfitLossDate, LocalDateTime createdAt) {
@@ -62,7 +62,7 @@ public class StrategyDetailResponse {
         this.winRate = winRate;
         this.subscriptionCount = subscriptionCount;
         this.isSubscribed = false;
-        this.imageUrl = imageUrl;
+        this.traderImgUrl = traderImgUrl;
         this.nickname = nickname;
         this.minimumInvestmentAmount = minimumInvestmentAmount.getDescription();
         this.initialInvestment = initialInvestment;

--- a/src/main/java/com/investmetic/domain/strategy/model/IsApproved.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/IsApproved.java
@@ -2,5 +2,6 @@ package com.investmetic.domain.strategy.model;
 
 public enum IsApproved {
     APPROVED,     // 승인 완료
-    PENDING       // 승인 대기 중
+    PENDING,       // 승인 대기 중
+    DENY         // 승인 거부
 }

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/DailyAnalysis.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/DailyAnalysis.java
@@ -9,12 +9,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DailyAnalysis extends BaseEntity {
 
     @Id

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/MonthlyAnalysis.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/MonthlyAnalysis.java
@@ -10,12 +10,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MonthlyAnalysis extends BaseEntity {
 
     @Id

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/StockType.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/StockType.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import lombok.Setter;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class StockType extends BaseEntity {

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/StockTypeGroup.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/StockTypeGroup.java
@@ -8,12 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StockTypeGroup extends BaseEntity {
 
     @Id

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/Strategy.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/Strategy.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -65,7 +66,8 @@ public class Strategy extends BaseEntity {
 
     private Integer subscriptionCount; // 구독수
 
-    private Double averageRating; // 평균별점
+    @ColumnDefault("0")
+    private Double averageRating = 0.0; // 평균별점
 
     public void updateAverageRating(Double newAverageRating) {
         this.averageRating = newAverageRating;

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/Strategy.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/Strategy.java
@@ -16,14 +16,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.math.BigDecimal;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Strategy extends BaseEntity {
 
     @Id
@@ -37,6 +38,10 @@ public class Strategy extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trade_type_id", nullable = false)
     private TradeType tradeType; // 매매유형
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "strategyStatistics_id")
+    private StrategyStatistics strategyStatistics;
 
     private String strategyName; // 전략명
 
@@ -68,12 +73,14 @@ public class Strategy extends BaseEntity {
 
     // FIXME :  전략 임시용 생성자입니다. 충돌시 아래 생성코드는 삭제해주시고, 작성하신것으로 사용해주세요 -오정훈-
     @Builder
-    public Strategy(Long strategyId, User user, TradeType tradeType, String strategyName, OperationCycle operationCycle,
-                    MinimumInvestmentAmount minimumInvestmentAmount, String strategyDescription, String proposalFilePath,
+    public Strategy(Long strategyId, User user,TradeType tradeType,StrategyStatistics strategyStatistics, String strategyName, OperationCycle operationCycle,
+                    MinimumInvestmentAmount minimumInvestmentAmount, String strategyDescription,
+                    String proposalFilePath,
                     IsPublic isPublic, IsApproved isApproved, Integer subscriptionCount, Double averageRating) {
         this.strategyId = strategyId;
         this.user = user;
         this.tradeType = tradeType;
+        this.strategyStatistics = strategyStatistics;
         this.strategyName = strategyName;
         this.operationCycle = operationCycle;
         this.minimumInvestmentAmount = minimumInvestmentAmount;

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/StrategyStatistics.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/StrategyStatistics.java
@@ -6,12 +6,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StrategyStatistics extends BaseEntity {
 
     @Id

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/StrategyStatistics.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/StrategyStatistics.java
@@ -2,12 +2,9 @@ package com.investmetic.domain.strategy.model.entity;
 
 import com.investmetic.global.common.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,10 +17,6 @@ public class StrategyStatistics extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long strategyStatisticsId;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "strategy_id", nullable = false)
-    private Strategy strategy;
 
     private Long balance; // 잔고
 

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/TradeType.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/TradeType.java
@@ -2,6 +2,7 @@ package com.investmetic.domain.strategy.model.entity;
 
 import com.investmetic.global.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class TradeType extends BaseEntity {

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepository.java
@@ -3,5 +3,5 @@ package com.investmetic.domain.strategy.repository;
 import com.investmetic.domain.strategy.model.entity.Strategy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StrategyRepository extends JpaRepository<Strategy,Long> {
+public interface StrategyRepository extends JpaRepository<Strategy, Long>, StrategyRepositoryCustom {
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
@@ -3,5 +3,5 @@ package com.investmetic.domain.strategy.repository;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
 
 public interface StrategyRepositoryCustom {
-    StrategyDetailResponse findStrategyDetail(Long strategyId, Long userId);
+    StrategyDetailResponse findStrategyDetail(Long strategyId);
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.investmetic.domain.strategy.repository;
+
+import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
+
+public interface StrategyRepositoryCustom {
+    StrategyDetailResponse findStrategyDetail(Long strategyId, Long userId);
+}

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
@@ -1,0 +1,44 @@
+package com.investmetic.domain.strategy.repository;
+
+import static com.investmetic.domain.strategy.model.entity.QStockType.stockType;
+import static com.investmetic.domain.strategy.model.entity.QStockTypeGroup.stockTypeGroup;
+import static com.investmetic.domain.strategy.model.entity.QStrategy.strategy;
+import static com.investmetic.domain.strategy.model.entity.QTradeType.tradeType;
+
+import com.investmetic.domain.strategy.dto.response.QStrategyDetailResponse;
+import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public StrategyDetailResponse findStrategyDetail(Long strategyId, Long userId) {
+        return jpaQueryFactory
+                .select(new QStrategyDetailResponse(
+                        strategy.strategyName,
+                        JPAExpressions.select(stockType.stockTypeIconURL)
+                                .from(stockTypeGroup)
+                                .join(stockTypeGroup.stockType, stockType)
+                                .where(stockTypeGroup.strategy.strategyId.eq(strategyId))
+                                .fetch(),
+                        tradeType.tradeIconPath,
+                        JPAExpressions.select(stockType.stockTypeName)
+                                .from(stockTypeGroup)
+                                .join(stockTypeGroup.stockType, stockType)
+                                .where(stockTypeGroup.strategy.strategyId.eq(strategyId))
+                                .fetch(),
+                        tradeType.tradeName,
+                        strategy.operationCycle,
+                        strategy.strategyDescription,
+
+
+                        )
+                );
+    }
+
+}

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
@@ -45,7 +45,7 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
                         strategy.strategyName,
                         // 종목 아이콘 URL 리스트 서브쿼리
                         Expressions.constant(stockTypeIconURLs), // List를 Expression으로 변환
-                        tradeType.tradeIconURL,
+                        tradeType.tradeTypeIconURL,
                         Expressions.constant(stockTypeNames), // List를 Expression으로 변환
                         tradeType.tradeTypeName,
                         strategy.operationCycle,

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
@@ -40,10 +40,9 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
         // 종목 이름목록
         List<String> stockTypeNames = getStockTypeIconURLs(stockTypes, stockType.stockTypeName);
 
-        StrategyDetailResponse strategyDetailResponse = queryFactory
+        return queryFactory
                 .select(new QStrategyDetailResponse(
                         strategy.strategyName,
-                        // 종목 아이콘 URL 리스트 서브쿼리
                         Expressions.constant(stockTypeIconURLs), // List를 Expression으로 변환
                         tradeType.tradeTypeIconURL,
                         Expressions.constant(stockTypeNames), // List를 Expression으로 변환
@@ -70,14 +69,12 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
                 .join(strategy.user, user)
                 .where(strategy.strategyId.eq(strategyId))
                 .fetchOne();
-
-        return strategyDetailResponse;
     }
 
     private @NotNull List<String> getStockTypeIconURLs(List<Tuple> stockTypes, StringPath stockType) {
         return stockTypes.stream()
                 .map(tuple -> tuple.get(stockType))
-                .collect(Collectors.toList());
+                .toList();
     }
 
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
@@ -1,44 +1,84 @@
+
 package com.investmetic.domain.strategy.repository;
 
 import static com.investmetic.domain.strategy.model.entity.QStockType.stockType;
 import static com.investmetic.domain.strategy.model.entity.QStockTypeGroup.stockTypeGroup;
 import static com.investmetic.domain.strategy.model.entity.QStrategy.strategy;
+import static com.investmetic.domain.strategy.model.entity.QStrategyStatistics.strategyStatistics;
 import static com.investmetic.domain.strategy.model.entity.QTradeType.tradeType;
+import static com.investmetic.domain.user.model.entity.QUser.user;
 
 import com.investmetic.domain.strategy.dto.response.QStrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
-import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 
 @RequiredArgsConstructor
 public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
 
-    private final JPAQueryFactory jpaQueryFactory;
+    private final JPAQueryFactory queryFactory;
 
     @Override
-    public StrategyDetailResponse findStrategyDetail(Long strategyId, Long userId) {
-        return jpaQueryFactory
+    public StrategyDetailResponse findStrategyDetail(Long strategyId) {
+
+        List<Tuple> stockTypes = queryFactory
+                .select(stockType.stockTypeIconURL, stockType.stockTypeName)
+                .from(stockTypeGroup)
+                .join(stockTypeGroup.stockType, stockType)
+                .where(stockTypeGroup.strategy.strategyId.eq(strategyId))
+                .fetch();
+
+        // 종목 아이콘 목록
+        List<String> stockTypeIconURLs = getStockTypeIconURLs(stockTypes, stockType.stockTypeIconURL);
+
+        // 종목 이름목록
+        List<String> stockTypeNames = getStockTypeIconURLs(stockTypes, stockType.stockTypeName);
+
+        StrategyDetailResponse strategyDetailResponse = queryFactory
                 .select(new QStrategyDetailResponse(
                         strategy.strategyName,
-                        JPAExpressions.select(stockType.stockTypeIconURL)
-                                .from(stockTypeGroup)
-                                .join(stockTypeGroup.stockType, stockType)
-                                .where(stockTypeGroup.strategy.strategyId.eq(strategyId))
-                                .fetch(),
-                        tradeType.tradeIconPath,
-                        JPAExpressions.select(stockType.stockTypeName)
-                                .from(stockTypeGroup)
-                                .join(stockTypeGroup.stockType, stockType)
-                                .where(stockTypeGroup.strategy.strategyId.eq(strategyId))
-                                .fetch(),
-                        tradeType.tradeName,
+                        // 종목 아이콘 URL 리스트 서브쿼리
+                        Expressions.constant(stockTypeIconURLs), // List를 Expression으로 변환
+                        tradeType.tradeIconURL,
+                        Expressions.constant(stockTypeNames), // List를 Expression으로 변환
+                        tradeType.tradeTypeName,
                         strategy.operationCycle,
                         strategy.strategyDescription,
+                        strategyStatistics.cumulativeProfitRate,
+                        strategyStatistics.maxDrawdownRate,
+                        strategyStatistics.averageProfitLossRate,
+                        strategyStatistics.profitFactor,
+                        strategyStatistics.winRate,
+                        strategy.subscriptionCount,
+                        user.imageUrl,
+                        user.nickname,
+                        strategy.minimumInvestmentAmount,
+                        strategyStatistics.initialInvestment,
+                        strategyStatistics.kpRatio,
+                        strategyStatistics.smScore,
+                        strategyStatistics.finalProfitLossDate,
+                        strategy.createdAt))
+                .from(strategy)
+                .join(strategy.strategyStatistics, strategyStatistics)
+                .join(strategy.tradeType, tradeType)
+                .join(strategy.user, user)
+                .where(strategy.strategyId.eq(strategyId))
+                .fetchOne();
 
+        return strategyDetailResponse;
+    }
 
-                        )
-                );
+    private @NotNull List<String> getStockTypeIconURLs(List<Tuple> stockTypes, StringPath stockType) {
+        return stockTypes.stream()
+                .map(tuple -> tuple.get(stockType))
+                .collect(Collectors.toList());
     }
 
 }
+

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyStatisticsRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyStatisticsRepository.java
@@ -1,13 +1,8 @@
 package com.investmetic.domain.strategy.repository;
 
 import com.investmetic.domain.strategy.model.entity.StrategyStatistics;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface StrategyStatisticsRepository extends JpaRepository<StrategyStatistics, Long> {
 
-    @Query("select s from StrategyStatistics s where s.strategy.strategyId = :strategyId")
-    Optional<StrategyStatistics> findByStrategy(@Param("strategyId") Long strategyId);
 }

--- a/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.investmetic.domain.subscription.repository;
+
+import com.investmetic.domain.subscription.model.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, SubscriptionRepositoryCustom {
+}

--- a/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.investmetic.domain.subscription.repository;
+
+public interface SubscriptionRepositoryCustom {
+    boolean existsByStrategyIdAndUserId(Long strategyId, Long userId);
+}

--- a/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepositoryCustomImpl.java
@@ -12,10 +12,9 @@ public class SubscriptionRepositoryCustomImpl implements SubscriptionRepositoryC
 
     @Override
     public boolean existsByStrategyIdAndUserId(Long strategyId, Long userId) {
-        Integer result = jpaQueryFactory.selectOne()
+        return jpaQueryFactory.selectOne()
                 .from(subscription)
                 .where(subscription.strategy.strategyId.eq(strategyId), subscription.user.userId.eq(userId))
-                .fetchFirst();
-        return result != null;
+                .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/subscription/repository/SubscriptionRepositoryCustomImpl.java
@@ -1,0 +1,21 @@
+package com.investmetic.domain.subscription.repository;
+
+import static com.investmetic.domain.subscription.model.entity.QSubscription.subscription;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SubscriptionRepositoryCustomImpl implements SubscriptionRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public boolean existsByStrategyIdAndUserId(Long strategyId, Long userId) {
+        Integer result = jpaQueryFactory.selectOne()
+                .from(subscription)
+                .where(subscription.strategy.strategyId.eq(strategyId), subscription.user.userId.eq(userId))
+                .fetchFirst();
+        return result != null;
+    }
+}

--- a/src/main/java/com/investmetic/global/exception/ErrorCode.java
+++ b/src/main/java/com/investmetic/global/exception/ErrorCode.java
@@ -57,7 +57,7 @@ public enum ErrorCode {
     ACCOUNT_IMAGE_QUERY_FAILED(HttpStatus.BAD_REQUEST, 3015, "실계좌 이미지 조회에 실패했습니다."),
     ACCOUNT_IMAGE_SAVE_FAILED(HttpStatus.BAD_REQUEST, 3016, "실계좌 이미지 등록/수정에 실패했습니다."),
     ACCOUNT_IMAGE_DELETE_FAILED(HttpStatus.BAD_REQUEST, 3017, "실계좌 이미지 삭제에 실패했습니다."),
-
+    STATISTICS_NOT_FOUND(HttpStatus.BAD_REQUEST,3018,"전략 통계가 존재하지 않습니다."),
 
     // 전략리뷰 관련오류(3300번대 );
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,3301,"해당 전략의 리뷰를 찾을 수 없습니다.");


### PR DESCRIPTION
## 📌 PR 개요
- 전략상세조회기능 구현

## #️⃣연관된 이슈

> ex) #14 

## 📝작업 내용

**- 전략 메인페이지 상세조회 구현**
**- 전략, 전략통계 엔티티(1:1)  주인을  전략통계 -> 전략엔티티로 변경** 

![image](https://github.com/user-attachments/assets/3f2d0d56-1b7f-47b3-aa52-b0c6b02cb388)

