### PR TITLE
✨ [feat] 실계좌 인증 이미지 삭제 기능 추가

### DIFF
--- a/src/main/java/com/investmetic/domain/accountverification/controller/AccountVerificationController.java
+++ b/src/main/java/com/investmetic/domain/accountverification/controller/AccountVerificationController.java
@@ -49,6 +49,7 @@ public class AccountVerificationController {
     }
 
     @PostMapping("/{strategyId}/delete-account-images")
+    @Operation(summary = "트레이더 전략 실계좌 인증 이미지 삭제 기능", description = "<a href='https://field-sting-eff.notion.site/3f07500f850b40e29eb70ccf5fe83ba1?pvs=4' target='_blank'>API 명세서</a>")
     public ResponseEntity<BaseResponse<Void>> deleteAccountImages(
             @PathVariable Long strategyId,
             @RequestBody List<Long> imageIds

--- a/src/main/java/com/investmetic/domain/accountverification/controller/AccountVerificationController.java
+++ b/src/main/java/com/investmetic/domain/accountverification/controller/AccountVerificationController.java
@@ -6,6 +6,7 @@ import com.investmetic.domain.strategy.dto.request.AccountImageRequestDto;
 import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.dto.MultiPresignedUrlResponseDto;
 import com.investmetic.global.exception.BaseResponse;
+import com.investmetic.global.exception.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,5 +46,14 @@ public class AccountVerificationController {
             @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable
     ) {
         return BaseResponse.success(accountVerificationService.getAccountImagesByStrategyId(strategyId, pageable));
+    }
+
+    @PostMapping("/{strategyId}/delete-account-images")
+    public ResponseEntity<BaseResponse<Void>> deleteAccountImages(
+            @PathVariable Long strategyId,
+            @RequestBody List<Long> imageIds
+    ) {
+        accountVerificationService.deleteStrategyAccountImages(strategyId, imageIds);
+        return BaseResponse.success(SuccessCode.DELETED);
     }
 }

--- a/src/main/java/com/investmetic/domain/accountverification/service/AccountVerificationService.java
+++ b/src/main/java/com/investmetic/domain/accountverification/service/AccountVerificationService.java
@@ -15,6 +15,7 @@ import com.investmetic.global.util.s3.FilePath;
 import com.investmetic.global.util.s3.S3FileService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -81,14 +82,24 @@ public class AccountVerificationService {
     public void deleteStrategyAccountImages(Long strategyId, List<Long> requestDtoList) {
         for (Long requestDtoId : requestDtoList) {
             Optional<AccountVerification> targetImage = accountVerificationRepository.findById(requestDtoId);
+
+            // 삭제 요청한 이미지가 존재하지 않을 경우
             if (targetImage.isEmpty()) {
                 throw new BusinessException(ErrorCode.ACCOUNT_IMAGE_NOT_FOUND);
             }
+
+            // 해당 실계좌 인증 이미지의 전략아이디가 요청한 전략아이디와 일치하지 않을경우
+            if (!Objects.equals(targetImage.get().getStrategy().getStrategyId(), strategyId)) {
+                throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND);
+            }
+
             AccountVerification imageEntity = targetImage.get();
+
             // FIXME: User 구현 후 수정 예정
 //            if (imageEntity.getCreatedBy() != user) {
 //                throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
 //            }
+            
             accountVerificationRepository.delete(imageEntity);
         }
     }

--- a/src/main/java/com/investmetic/domain/accountverification/service/AccountVerificationService.java
+++ b/src/main/java/com/investmetic/domain/accountverification/service/AccountVerificationService.java
@@ -15,6 +15,7 @@ import com.investmetic.global.util.s3.FilePath;
 import com.investmetic.global.util.s3.S3FileService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -74,5 +75,21 @@ public class AccountVerificationService {
     public PageResponseDto<AccountImagesResponseDto> getAccountImagesByStrategyId(Long strategyId, Pageable pageable) {
         return new PageResponseDto<>(accountVerificationRepository.findByStrategy_StrategyId(strategyId, pageable)
                 .map(AccountImagesResponseDto::from));
+    }
+
+    @Transactional
+    public void deleteStrategyAccountImages(Long strategyId, List<Long> requestDtoList) {
+        for (Long requestDtoId : requestDtoList) {
+            Optional<AccountVerification> targetImage = accountVerificationRepository.findById(requestDtoId);
+            if (targetImage.isEmpty()) {
+                throw new BusinessException(ErrorCode.ACCOUNT_IMAGE_NOT_FOUND);
+            }
+            AccountVerification imageEntity = targetImage.get();
+            // FIXME: User 구현 후 수정 예정
+//            if (imageEntity.getCreatedBy() != user) {
+//                throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
+//            }
+            accountVerificationRepository.delete(imageEntity);
+        }
     }
 }

--- a/src/main/java/com/investmetic/global/exception/ErrorCode.java
+++ b/src/main/java/com/investmetic/global/exception/ErrorCode.java
@@ -63,8 +63,9 @@ public enum ErrorCode {
     ANALYSIS_OPTION_NOT_FOUND(HttpStatus.BAD_REQUEST, 3019, "유효하지 않은 옵션입니다."),
     DAILY_ANALYSIS_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 3020, "해당 날짜의 전략 통계가 이미 존재합니다."),
 
-    STOCKTYPE_NOT_FOUND(HttpStatus.BAD_REQUEST,3021,"해당 종목이 존재하지 않습니다."),
+    STOCKTYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, 3021, "해당 종목이 존재하지 않습니다."),
     TRADETYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, 3022, "해당 매매 유형이 존재하지 않습니다."),
+    ACCOUNT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 3030, "해당 실계좌 인증 이미지가 존재하지 않습니다."),
 
     // 전략리뷰 관련오류(3300번대 );
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, 3301, "해당 전략의 리뷰를 찾을 수 없습니다.");


### PR DESCRIPTION
## 📌 PR 개요
- 실계좌 인증 이미지 삭제

## #️⃣연관된 이슈

> #29 

## 📝작업 내용

- 실계좌 인증 이미지 삭제
- 실계좌 인증 이미지 삭제 테스트 코드 추가
- 추후 사용자 개발 완료 되면 생성자(유저)만 삭제 가능하도록 수정 예정