### PR TITLE
Feat/download proposal #8

### DIFF
--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -12,7 +12,6 @@ import com.investmetic.global.exception.BaseResponse;
 import com.investmetic.global.exception.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -72,13 +70,12 @@ public class StrategyController {
     }
 
     @GetMapping("/{strategyId}/download-proposal")
-    public ResponseEntity<Resource> downloadProposal(@PathVariable Long strategyId)
-            throws UnsupportedEncodingException {
+    @Operation(summary = "트레이더 전략 제안서 다운로드 기능", description = "<a href='https://field-sting-eff.notion.site/0b7c02614c9e485180a3f2e010773c11?pvs=4' target='_blank'>API 명세서</a>")
+    public ResponseEntity<Resource> downloadProposal(@PathVariable Long strategyId) {
         FileDownloadResponseDto fileDownloadResponse = strategyService.downloadFileFromUrl(strategyId);
 
-        String encodedFileName = URLEncoder.encode(fileDownloadResponse.getDownloadFileName(),
-                        StandardCharsets.UTF_8)
-                .replaceAll("\\+", "%20");
+        String encodedFileName = URLEncoder.encode(fileDownloadResponse.getDownloadFileName(), StandardCharsets.UTF_8)
+                .replace("+", "%20");
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .header(HttpHeaders.CONTENT_DISPOSITION,

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -6,13 +6,20 @@ import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
 import com.investmetic.domain.strategy.service.StrategyAnalysisService;
 import com.investmetic.domain.strategy.service.StrategyRegisterService;
 import com.investmetic.domain.strategy.service.StrategyService;
+import com.investmetic.global.dto.FileDownloadResponseDto;
 import com.investmetic.global.dto.PresignedUrlResponseDto;
 import com.investmetic.global.exception.BaseResponse;
 import com.investmetic.global.exception.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -61,5 +69,20 @@ public class StrategyController {
     ) {
         strategyService.updateVisibility(strategyId);
         return BaseResponse.success(SuccessCode.UPDATED);
+    }
+
+    @GetMapping("/{strategyId}/download-proposal")
+    public ResponseEntity<Resource> downloadProposal(@PathVariable Long strategyId)
+            throws UnsupportedEncodingException {
+        FileDownloadResponseDto fileDownloadResponse = strategyService.downloadFileFromUrl(strategyId);
+
+        String encodedFileName = URLEncoder.encode(fileDownloadResponse.getDownloadFileName(),
+                        StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + encodedFileName + "\"")
+                .body(fileDownloadResponse.getResource());
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
@@ -1,11 +1,18 @@
 package com.investmetic.domain.strategy.service;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.investmetic.domain.strategy.model.IsPublic;
 import com.investmetic.domain.strategy.model.entity.Strategy;
 import com.investmetic.domain.strategy.repository.StrategyRepository;
+import com.investmetic.global.dto.FileDownloadResponseDto;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
+import com.investmetic.global.util.s3.S3FileService;
+import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StrategyService {
     private final StrategyRepository strategyRepository;
+    private final S3FileService s3FileService;
+    private final AmazonS3Client amazonS3Client;
 
     @Transactional
     public void updateVisibility(Long strategyId) {
@@ -24,8 +33,47 @@ public class StrategyService {
 //            throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
 //        }
 
-        strategy.setIsPublic(strategy.getIsPublic() == IsPublic.PUBLIC
-                ? IsPublic.PRIVATE
-                : IsPublic.PUBLIC);
+        strategy.setIsPublic(strategy.getIsPublic() == IsPublic.PUBLIC ? IsPublic.PRIVATE : IsPublic.PUBLIC);
+    }
+
+    @Transactional(readOnly = true)
+    public FileDownloadResponseDto downloadFileFromUrl(Long strategyId) {
+        // 전략 조회 및 유효성 검사
+        Strategy strategy = strategyRepository.findById(strategyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STRATEGY_NOT_FOUND));
+
+        String proposalFilePath = strategy.getProposalFilePath();
+        if (proposalFilePath == null || proposalFilePath.isBlank()) {
+            throw new BusinessException(ErrorCode.PROPOSAL_NOT_FOUND);
+        }
+
+        // S3 파일 키 추출 및 파일 가져오기
+        try {
+            S3Object s3Object = s3FileService.extractFileKeyFromUrl(proposalFilePath);
+
+            S3ObjectInputStream inputStream = s3Object.getObjectContent();
+
+            String fileExtension = extractFileExtension(proposalFilePath);
+
+            // 다운로드 시 파일명 변경
+            String newFileName = strategy.getStrategyName() + "_제안서" + fileExtension;
+
+            // InputStreamResource 생성
+            InputStreamResource resource = new InputStreamResource(inputStream);
+
+            return FileDownloadResponseDto.builder().downloadFileName(newFileName).resource(resource).build();
+
+        } catch (URISyntaxException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 파일 확장자 추출 메서드
+    private String extractFileExtension(String filePath) {
+        int lastDotIndex = filePath.lastIndexOf(".");
+        if (lastDotIndex == -1 || lastDotIndex == filePath.length() - 1) {
+            return ""; // 확장자가 없거나 잘못된 경우 빈 문자열 반환
+        }
+        return filePath.substring(lastDotIndex); // "." 포함하여 반환
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyService.java
@@ -10,6 +10,7 @@ import com.investmetic.global.dto.FileDownloadResponseDto;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
 import com.investmetic.global.util.s3.S3FileService;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
@@ -48,11 +49,10 @@ public class StrategyService {
         }
 
         // S3 파일 키 추출 및 파일 가져오기
-        try {
-            S3Object s3Object = s3FileService.extractFileKeyFromUrl(proposalFilePath);
-
-            S3ObjectInputStream inputStream = s3Object.getObjectContent();
-
+        try (
+                S3Object s3Object = s3FileService.extractFileKeyFromUrl(proposalFilePath);
+                S3ObjectInputStream inputStream = s3Object.getObjectContent()
+        ) {
             String fileExtension = extractFileExtension(proposalFilePath);
 
             // 다운로드 시 파일명 변경
@@ -61,9 +61,12 @@ public class StrategyService {
             // InputStreamResource 생성
             InputStreamResource resource = new InputStreamResource(inputStream);
 
-            return FileDownloadResponseDto.builder().downloadFileName(newFileName).resource(resource).build();
+            return FileDownloadResponseDto.builder()
+                    .downloadFileName(newFileName)
+                    .resource(resource)
+                    .build();
 
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | IOException e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/investmetic/global/dto/FileDownloadResponseDto.java
+++ b/src/main/java/com/investmetic/global/dto/FileDownloadResponseDto.java
@@ -1,0 +1,18 @@
+package com.investmetic.global.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.core.io.Resource;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FileDownloadResponseDto {
+    private String downloadFileName;
+    private Resource resource;
+}
+

--- a/src/main/java/com/investmetic/global/util/s3/S3FileService.java
+++ b/src/main/java/com/investmetic/global/util/s3/S3FileService.java
@@ -6,8 +6,11 @@ import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -232,6 +235,16 @@ public class S3FileService {
             //실패시
             throw new RuntimeException("파일을 삭제하는데 실패했습니다.");
         }
+    }
+
+    /**
+     * URL에서 S3 파일 키 추출
+     */
+    public S3Object extractFileKeyFromUrl(String fileUrl) throws URISyntaxException {
+        URI uri = new URI(fileUrl);
+        String path = uri.getPath(); // 경로 추출
+        // S3에서 파일 가져오기
+        return amazonS3.getObject(bucketName, path.substring(1));
     }
 
 

--- a/src/test/java/com/investmetic/domain/strategy/service/FileDownloadServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/FileDownloadServiceTest.java
@@ -1,0 +1,104 @@
+package com.investmetic.domain.strategy.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.investmetic.domain.strategy.model.entity.Strategy;
+import com.investmetic.domain.strategy.repository.StrategyRepository;
+import com.investmetic.global.dto.FileDownloadResponseDto;
+import com.investmetic.global.exception.BusinessException;
+import com.investmetic.global.exception.ErrorCode;
+import com.investmetic.global.util.s3.S3FileService;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FileDownloadServiceTest {
+
+    @InjectMocks
+    private StrategyService strategyService;
+
+    @Mock
+    private StrategyRepository strategyRepository;
+
+    @Mock
+    private S3FileService s3FileService;
+
+    @Test
+    @DisplayName("파일 다운로드 - 성공")
+    void 테스트_1() throws URISyntaxException {
+        Long strategyId = 1L;
+        String proposalFilePath = "https://s3.amazonaws.com/bucket-name/path/to/file/example.pdf";
+        Strategy mockStrategy = Strategy.builder()
+                .strategyId(strategyId)
+                .proposalFilePath(proposalFilePath)
+                .build();
+
+        S3Object mockS3Object = mock(S3Object.class);
+        S3ObjectInputStream mockInputStream = mock(S3ObjectInputStream.class);
+
+        when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(mockStrategy));
+        when(s3FileService.extractFileKeyFromUrl(proposalFilePath)).thenReturn(mockS3Object);
+        when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
+
+        FileDownloadResponseDto response = strategyService.downloadFileFromUrl(strategyId);
+
+        assertNotNull(response);
+        assertTrue(response.getDownloadFileName().endsWith(".pdf"));
+        assertNotNull(response.getResource());
+
+        verify(strategyRepository, times(1)).findById(strategyId);
+        verify(s3FileService, times(1)).extractFileKeyFromUrl(proposalFilePath);
+        verify(mockS3Object, times(1)).getObjectContent();
+    }
+
+    @Test
+    @DisplayName("파일 다운로드 - 실패 (전략 없음)")
+    void 테스트_2() {
+        Long strategyId = 999L;
+        when(strategyRepository.findById(strategyId)).thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                strategyService.downloadFileFromUrl(strategyId)
+        );
+
+        assertEquals(ErrorCode.STRATEGY_NOT_FOUND, exception.getErrorCode());
+        verify(strategyRepository, times(1)).findById(strategyId);
+        verifyNoInteractions(s3FileService);
+    }
+
+    @Test
+    @DisplayName("파일 다운로드 - 실패 (파일 경로 없음)")
+    void 테스트_3() {
+        Long strategyId = 1L;
+        Strategy mockStrategy = Strategy.builder()
+                .strategyId(strategyId)
+                .proposalFilePath(null)
+                .build();
+
+        when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(mockStrategy));
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                strategyService.downloadFileFromUrl(strategyId)
+        );
+
+        assertEquals(ErrorCode.PROPOSAL_NOT_FOUND, exception.getErrorCode());
+        verify(strategyRepository, times(1)).findById(strategyId);
+        verifyNoInteractions(s3FileService);
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
- 제안서 다운 기능 구현

## #️⃣연관된 이슈

> #8 

## 📝작업 내용

- 제안서 다운로드 요청 시 해당 제안서를 [트레이더전략명_제안서.확장자명] 으로 다운로드 하는 기능

## 참고 사항
- 클라이언트에서 바로 AWS S3로 다운로드하면 파일명 그대로 다운로드 되기 때문에 서버 요청 시 다운로드가 가능하게 하였습니다.
- 그렇기 때문에 컨트롤러 반환이 기존 BaseResponse와 다릅니다.
