### PR TITLE
Feat/trader list #26

### DIFF
--- a/src/main/java/com/investmetic/domain/subscription/model/entity/Subscription.java
+++ b/src/main/java/com/investmetic/domain/subscription/model/entity/Subscription.java
@@ -11,13 +11,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Subscription extends BaseEntity {
 
     @Builder

--- a/src/main/java/com/investmetic/domain/subscription/model/entity/Subscription.java
+++ b/src/main/java/com/investmetic/domain/subscription/model/entity/Subscription.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class Subscription extends BaseEntity {
+
+    @Builder
+    public Subscription(Long id, Strategy strategy, User user) {
+        this.id = id;
+        this.strategy = strategy;
+        this.user = user;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subscription_id")

--- a/src/main/java/com/investmetic/domain/user/controller/UserController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/UserController.java
@@ -61,15 +61,16 @@ public class UserController {
 
     /**
      * 트레이더 목록 조회
-     * @param orderBy 정렬할 조건, null 가능
-     * @param keyword 닉네임 검색 키워드, null 가능
+     *
+     * @param orderBy  정렬할 조건, null 가능
+     * @param keyword  닉네임 검색 키워드, null 가능
      * @param pageable 현재 페이지, 사이즈 - 디자인에서는 12개로 확인됨.
-     * */
+     */
     @GetMapping("/traders")
-    public ResponseEntity<BaseResponse<PageResponseDto<TraderProfileDto>>> getTraderList(@RequestParam String orderBy,
-                                                                                         @RequestParam String keyword,
-                                                                                         @RequestParam Pageable pageable) {
-
+    public ResponseEntity<BaseResponse<PageResponseDto<TraderProfileDto>>> getTraderList(
+            @RequestParam String orderBy,
+            @RequestParam String keyword,
+            @RequestParam Pageable pageable) {
         return BaseResponse.success(userService.getTraderList(orderBy, keyword, pageable));
 
     }

--- a/src/main/java/com/investmetic/domain/user/controller/UserController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.investmetic.domain.user.controller;
 
 import com.investmetic.domain.user.dto.request.UserSignUpDto;
+import com.investmetic.domain.user.dto.response.TraderProfileDto;
 import com.investmetic.domain.user.service.UserService;
+import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.exception.BaseResponse;
 import com.investmetic.global.exception.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,8 +25,7 @@ public class UserController {
 
     //회원가입
     @PostMapping("/signup")
-    public ResponseEntity<BaseResponse<Void>> signup(
-            @RequestBody UserSignUpDto userSignUpDto) {
+    public ResponseEntity<BaseResponse<Void>> signup(@RequestBody UserSignUpDto userSignUpDto) {
         userService.signUp(userSignUpDto);
 
         return BaseResponse.success(SuccessCode.CREATED);
@@ -32,8 +34,7 @@ public class UserController {
 
     //닉네임 중복 검사
     @GetMapping("/check/nickname")
-    public ResponseEntity<BaseResponse<Boolean>> checkNicknameDuplicate(
-            @RequestParam String nickname) {
+    public ResponseEntity<BaseResponse<Boolean>> checkNicknameDuplicate(@RequestParam String nickname) {
 
         boolean response = userService.checkNicknameDuplicate(nickname);
 
@@ -42,8 +43,7 @@ public class UserController {
 
     // 이메일 중복 검사
     @GetMapping("/check/email")
-    public ResponseEntity<BaseResponse<Boolean>> checkEmailDuplicate(
-            @RequestParam String email) {
+    public ResponseEntity<BaseResponse<Boolean>> checkEmailDuplicate(@RequestParam String email) {
 
         boolean response = userService.checkEmailDuplicate(email);
 
@@ -52,11 +52,25 @@ public class UserController {
 
     // 전화번호 중복 검사
     @GetMapping("/check/phone")
-    public ResponseEntity<BaseResponse<Boolean>> checkPhoneDuplicate(
-            @RequestParam String phone) {
+    public ResponseEntity<BaseResponse<Boolean>> checkPhoneDuplicate(@RequestParam String phone) {
 
         boolean isDuplicate = userService.checkPhoneDuplicate(phone);
 
         return BaseResponse.success(isDuplicate);
+    }
+
+    /**
+     * 트레이더 목록 조회
+     * @param orderBy 정렬할 조건, null 가능
+     * @param keyword 닉네임 검색 키워드, null 가능
+     * @param pageable 현재 페이지, 사이즈 - 디자인에서는 12개로 확인됨.
+     * */
+    @GetMapping("/traders")
+    public ResponseEntity<BaseResponse<PageResponseDto<TraderProfileDto>>> getTraderList(@RequestParam String orderBy,
+                                                                                         @RequestParam String keyword,
+                                                                                         @RequestParam Pageable pageable) {
+
+        return BaseResponse.success(userService.getTraderList(orderBy, keyword, pageable));
+
     }
 }

--- a/src/main/java/com/investmetic/domain/user/dto/response/TraderProfileDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/response/TraderProfileDto.java
@@ -1,0 +1,32 @@
+package com.investmetic.domain.user.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class TraderProfileDto {
+
+    private long userId;
+    private String userName;
+    private String nickname;
+    private String imageUrl;
+    private long strategyCount;
+    private long totalSubCount;
+
+
+    @QueryProjection
+    public TraderProfileDto(long userId, String userName, String nickname, String imageUrl, long strategyCount,
+                            long totalSubCount) {
+        this.userId = userId;
+        this.userName = userName;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+        this.strategyCount = strategyCount;
+        this.totalSubCount = totalSubCount;
+    }
+}

--- a/src/main/java/com/investmetic/domain/user/dto/response/TraderProfileDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/response/TraderProfileDto.java
@@ -9,17 +9,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TraderProfileDto {
 
-    private long userId;
+    private Long userId;
     private String userName;
     private String nickname;
     private String imageUrl;
-    private long strategyCount;
-    private int totalSubCount;
+    private Long strategyCount;
+    private Integer totalSubCount;
 
 
     @QueryProjection
-    public TraderProfileDto(long userId, String userName, String nickname, String imageUrl, long strategyCount,
-                            int totalSubCount) {
+    public TraderProfileDto(Long userId, String userName, String nickname, String imageUrl, Long strategyCount,
+                            Integer totalSubCount) {
         this.userId = userId;
         this.userName = userName;
         this.nickname = nickname;

--- a/src/main/java/com/investmetic/domain/user/dto/response/TraderProfileDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/response/TraderProfileDto.java
@@ -16,12 +16,12 @@ public class TraderProfileDto {
     private String nickname;
     private String imageUrl;
     private long strategyCount;
-    private long totalSubCount;
+    private int totalSubCount;
 
 
     @QueryProjection
     public TraderProfileDto(long userId, String userName, String nickname, String imageUrl, long strategyCount,
-                            long totalSubCount) {
+                            int totalSubCount) {
         this.userId = userId;
         this.userName = userName;
         this.nickname = nickname;

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepository.java
@@ -16,4 +16,5 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     @Query("select u.password from User u where u.email = :email")
     Optional<String> findPasswordByEmail(@Param("email")String email);
+
 }

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.investmetic.domain.user.repository;
 
 import com.investmetic.domain.user.dto.request.UserAdminPageRequestDto;
+import com.investmetic.domain.user.dto.response.TraderProfileDto;
 import com.investmetic.domain.user.dto.response.UserProfileDto;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,8 @@ public interface UserRepositoryCustom {
     Optional<UserProfileDto> findByPhoneUserInfo(String phone);
 
     Page<UserProfileDto> getAdminUsersPage(UserAdminPageRequestDto requestDto, Pageable pageRequest);
+
+    Page<TraderProfileDto> getTraderListPage(String OrderBy,String traderNickname, Pageable pageRequest);
 
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
@@ -17,7 +17,7 @@ public interface UserRepositoryCustom {
 
     Page<UserProfileDto> getAdminUsersPage(UserAdminPageRequestDto requestDto, Pageable pageRequest);
 
-    Page<TraderProfileDto> getTraderListPage(String OrderBy,String traderNickname, Pageable pageRequest);
+    Page<TraderProfileDto> getTraderListPage(String orderBy, String traderNickname, Pageable pageRequest);
 
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/investmetic/domain/user/service/UserService.java
+++ b/src/main/java/com/investmetic/domain/user/service/UserService.java
@@ -78,14 +78,14 @@ public class UserService {
      *
      * @param orderBy null일 때 구독순
      * @param keyword null일 때 키워드 검색 x
-     * */
+     */
     @Transactional(readOnly = true)
-    public PageResponseDto<TraderProfileDto> getTraderList(String orderBy, String keyword, Pageable pageable){
+    public PageResponseDto<TraderProfileDto> getTraderList(String orderBy, String keyword, Pageable pageable) {
 
-        Page<TraderProfileDto> page =  userRepository.getTraderListPage(orderBy, keyword, pageable);
+        Page<TraderProfileDto> page = userRepository.getTraderListPage(orderBy, keyword, pageable);
 
         // 조회된 트레이더가 없을 때
-        if(page.getContent().isEmpty()){
+        if (page.getContent().isEmpty()) {
             throw new BusinessException(ErrorCode.TRADER_LIST_RETRIEVAL_FAILED);
         }
 

--- a/src/main/java/com/investmetic/domain/user/service/UserService.java
+++ b/src/main/java/com/investmetic/domain/user/service/UserService.java
@@ -1,11 +1,15 @@
 package com.investmetic.domain.user.service;
 
 import com.investmetic.domain.user.dto.request.UserSignUpDto;
+import com.investmetic.domain.user.dto.response.TraderProfileDto;
 import com.investmetic.domain.user.model.entity.User;
 import com.investmetic.domain.user.repository.UserRepository;
+import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,5 +71,24 @@ public class UserService {
         }
 
         return userRepository.existsByPhone(phone);
+    }
+
+    /**
+     * 트레이더 목록 조회
+     *
+     * @param orderBy null일 때 구독순
+     * @param keyword null일 때 키워드 검색 x
+     * */
+    @Transactional(readOnly = true)
+    public PageResponseDto<TraderProfileDto> getTraderList(String orderBy, String keyword, Pageable pageable){
+
+        Page<TraderProfileDto> page =  userRepository.getTraderListPage(orderBy, keyword, pageable);
+
+        // 조회된 트레이더가 없을 때
+        if(page.getContent().isEmpty()){
+            throw new BusinessException(ErrorCode.TRADER_LIST_RETRIEVAL_FAILED);
+        }
+
+        return new PageResponseDto<>(page);
     }
 }

--- a/src/test/java/com/investmetic/domain/user/repository/AdminPageUserRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/AdminPageUserRepositoryTest.java
@@ -84,8 +84,6 @@ class AdminPageUserRepositoryTest {
             Page<UserProfileDto> users = userRepository.getAdminUsersPage(requestDto, pageable);
 
             //then
-            assertThat(users.getTotalElements()).isEqualTo(40L); // Super_admin 뺀값
-
             long higher = Long.MAX_VALUE;
             //최신순으로 정렬되어있는지 확인.
             for (UserProfileDto user : users) {

--- a/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.investmetic.domain.user.repository;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.investmetic.domain.strategy.model.IsApproved;
 import com.investmetic.domain.strategy.model.IsPublic;
 import com.investmetic.domain.strategy.model.entity.Strategy;
@@ -16,37 +18,40 @@ import com.investmetic.domain.user.model.entity.User;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@Transactional
+@TestInstance(Lifecycle.PER_CLASS)
 class TraderListRepositoryTest {
 
-    private final List<Role> roles = new ArrayList<>(
+    private static final List<Role> roles = new ArrayList<>(
             List.of(Role.TRADER, Role.TRADER_ADMIN, Role.INVESTOR, Role.INVESTOR_ADMIN, Role.SUPER_ADMIN));
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private StrategyRepository strategyRepository;
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
 
     @Autowired
-    private TradeTypeRepository tradeTypeRepository;
+    private  UserRepository userRepository;
+    @Autowired
+    private  StrategyRepository strategyRepository;
+    @Autowired
+    private  SubscriptionRepository subscriptionRepository;
 
-    // 10명이 trader
-    @BeforeEach
+    @Autowired
+    private  TradeTypeRepository tradeTypeRepository;
+
+    // 트레이더 생성.... 더 자세하게 보려면 데이터가 필요하겠네요.
+    @BeforeAll
     void createUsers50() {
-        Strategy strategy = null;
-        TradeType tradeType = new TradeType(1L, "파괴적",true,"asdf.jpg");
+        Strategy strategy1 = null;
+        Strategy strategy2 = null;
+        TradeType tradeType = new TradeType(1L, "파괴적", true, "asdf.jpg");
 
         tradeTypeRepository.save(tradeType);
 
@@ -58,20 +63,33 @@ class TraderListRepositoryTest {
                     .email("jlwoo0925" + i + "@gmail.com").password("asdf" + i)
                     .imageUrl("jrw_projectS3/profile/정룡우.img").phone("010123456" + dc.format(i)).birthDate("000925")
                     .ipAddress("127.0.0.1").infoAgreement(Boolean.FALSE).userState(UserState.ACTIVE)
+                    // Trader 20명 생성.
                     .role(roles.get(i % 5)).build();
 
             userRepository.save(user);
 
-            if (user.getRole() == Role.TRADER||user.getRole() == Role.TRADER_ADMIN) {
-                strategy = Strategy.builder().user(user).tradeType(tradeType).strategyName("전략" + i).isPublic(IsPublic.PUBLIC)
-                        .isApproved(IsApproved.APPROVED).build();
+            // Trader 전략 만들기.
+            if ((user.getRole() == Role.TRADER || user.getRole() == Role.TRADER_ADMIN) && (i < 40)) {
+                strategy1 = Strategy.builder().user(user).tradeType(tradeType).strategyName("전략" + i)
+                        .isPublic(IsPublic.PUBLIC).isApproved(IsApproved.APPROVED).build();
 
-                strategyRepository.save(strategy);
+                // Role이 Trader인 사람은 전략을 2개씩 가짐.
+                if (user.getRole() == Role.TRADER) {
+                    strategy2 = Strategy.builder().user(user).tradeType(tradeType).strategyName("전략" + i)
+                            .isPublic(IsPublic.PUBLIC).isApproved(IsApproved.APPROVED).build();
+                    strategyRepository.save(strategy2);
+
+                    Subscription subscription1 = Subscription.builder().user(user).strategy(strategy2).build();
+                    subscriptionRepository.save(subscription1);
+                }
+
+                strategyRepository.save(strategy1);
+
             }
 
-            if(strategy != null) {
-                 Subscription subscription = Subscription.builder().user(user).strategy(strategy).build();
-                 subscriptionRepository.save(subscription);
+            if (strategy1 != null) {
+                Subscription subscription2 = Subscription.builder().user(user).strategy(strategy1).build();
+                subscriptionRepository.save(subscription2);
             }
 
         }
@@ -79,14 +97,119 @@ class TraderListRepositoryTest {
 
 
     @Test
-    @DisplayName("트레이더 목록 조회 테스트.")
-    void TraderListRepositoryTest1() {
+    @DisplayName("트레이더 목록 조회 테스트.(구독수 순)")
+    void TraderListRepositoryTest1(){
+
+
+        // given 가장 큰수로 설정
+        long bigger = Integer.MAX_VALUE;
+        int pagesize = 5;
+        String orderBy = null;
+
+        Pageable pageable = PageRequest.of(0, pagesize);
+
+        // when
+        Page<TraderProfileDto> page = userRepository.getTraderListPage(orderBy, null, pageable);
+
+        // then
         //구독순 확인.
-        Pageable pageable = PageRequest.of(0, 4);
-        Page<TraderProfileDto> page =userRepository.getTraderListPage(null,null,pageable);
-        for (TraderProfileDto traderProfileDto : page.getContent()) {
-            System.out.println(traderProfileDto);
+        for(int i = 1; i<=page.getTotalPages(); i++){
+
+            for(TraderProfileDto traderProfileDto : page.getContent()){
+                // 앞순서의 트레이너의 구독자 수보다 작거나 같아야함.
+                assertThat(traderProfileDto.getTotalSubCount()).isLessThanOrEqualTo(bigger);
+
+                // 현재 순서의 트레이너 구독자 수 대입.
+                bigger = traderProfileDto.getTotalSubCount();
+            }
+
+            // 해당 페이지가 마지막 페이지이면 종료.
+            if(i==page.getTotalPages()) break;
+
+            // 페이지 증가시키면서 확인.
+            Pageable nextPage = PageRequest.of(i,pagesize);
+            page = userRepository.getTraderListPage(orderBy, null, nextPage);
         }
     }
+
+
+    @Test
+    @DisplayName("트레이더 목록 조회 테스트. (전략수순)")
+    void TraderListRepositoryTest2(){
+
+        // given 가장 큰수로 설정
+        long bigger = Integer.MAX_VALUE;
+        int pagesize = 5;
+        String orderBy = "STRATEGY_TOTAL";
+
+        Pageable pageable = PageRequest.of(0, pagesize);
+
+        // when - (orderBy = STRATEGY_TOTAL)
+        Page<TraderProfileDto> page = userRepository.getTraderListPage(orderBy, null, pageable);
+
+        // then
+        // 전략수 순
+        for(int i = 1; i<=page.getTotalPages(); i++){
+
+            for(TraderProfileDto traderProfileDto : page.getContent()){
+                // 앞순서의 트레이너가 가진 전략수보다 작거나 같아야함.
+                assertThat(traderProfileDto.getStrategyCount()).isLessThanOrEqualTo(bigger);
+
+                // 현재 순서의 트레이너 전략수 대입.
+                bigger = traderProfileDto.getStrategyCount();
+            }
+            System.out.println(page.getContent().size());
+
+            if(i==page.getTotalPages()) break;
+
+            Pageable nextPage = PageRequest.of(i,pagesize);
+            page = userRepository.getTraderListPage(orderBy, null, nextPage);
+        }
+    }
+
+
+    @Test
+    @DisplayName("트레이더 목록 조회 테스트.(닉네임 조회)")
+    void TraderListRepositoryTest3(){
+
+
+        // given
+        long bigger = Integer.MAX_VALUE;
+        int pagesize = 5;
+        String keyword = "2";
+        String orderBy = null;
+
+        Pageable pageable = PageRequest.of(0, pagesize);
+
+        // when - 닉네임에 2가 들어가는지
+        Page<TraderProfileDto> page = userRepository.getTraderListPage(orderBy, keyword, pageable);
+
+        // then
+        //구독순 확인, 닉네임에 해당 keyword가 들어가는지 확인.
+        for(int i = 1; i<=page.getTotalPages(); i++){
+
+            for(TraderProfileDto traderProfileDto : page.getContent()){
+
+                // 앞순서의 트레이너의 구독자 수보다 작거나 같아야함.
+                assertThat(traderProfileDto.getTotalSubCount()).isLessThanOrEqualTo(bigger);
+
+                //닉네임에 해당 keyword가 들어가는지 확인.
+                assertThat(traderProfileDto.getNickname()).contains(keyword);
+
+                // 현재 순서의 트레이너 구독자 수 대입.
+                bigger = traderProfileDto.getTotalSubCount();
+            }
+
+            // 해당 페이지가 마지막 페이지이면 종료.
+            if(i==page.getTotalPages()) break;
+
+            // 페이지 증가시키면서 확인.
+            Pageable nextPage = PageRequest.of(i,pagesize);
+            page = userRepository.getTraderListPage(orderBy, null, nextPage);
+        }
+    }
+
+
+
 
 }

--- a/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
@@ -70,7 +70,6 @@ class TraderListRepositoryTest {
                     .ipAddress("127.0.0.1")
                     .infoAgreement(Boolean.FALSE)
                     .userState(UserState.ACTIVE)
-                    // Trader 20명 생성.
                     .role(roles.get(i % 5)).build();
 
             userRepository.save(user);
@@ -121,8 +120,8 @@ class TraderListRepositoryTest {
     void TraderListRepositoryTest1() {
 
         // given 가장 큰수로 설정
-        int bigger = Integer.MAX_VALUE;
-        int pagesize = 100;
+        Integer bigger = Integer.MAX_VALUE;
+        Integer pagesize = 100;
         String orderBy = null;
 
         Pageable pageable = PageRequest.of(0, pagesize);

--- a/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.investmetic.domain.user.repository;
+
+
+import com.investmetic.domain.strategy.model.IsApproved;
+import com.investmetic.domain.strategy.model.IsPublic;
+import com.investmetic.domain.strategy.model.entity.Strategy;
+import com.investmetic.domain.strategy.model.entity.TradeType;
+import com.investmetic.domain.strategy.repository.StrategyRepository;
+import com.investmetic.domain.strategy.repository.TradeTypeRepository;
+import com.investmetic.domain.subscription.model.entity.Subscription;
+import com.investmetic.domain.subscription.repository.SubscriptionRepository;
+import com.investmetic.domain.user.dto.response.TraderProfileDto;
+import com.investmetic.domain.user.model.Role;
+import com.investmetic.domain.user.model.UserState;
+import com.investmetic.domain.user.model.entity.User;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class TraderListRepositoryTest {
+
+    private final List<Role> roles = new ArrayList<>(
+            List.of(Role.TRADER, Role.TRADER_ADMIN, Role.INVESTOR, Role.INVESTOR_ADMIN, Role.SUPER_ADMIN));
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private StrategyRepository strategyRepository;
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private TradeTypeRepository tradeTypeRepository;
+
+    // 10명이 trader
+    @BeforeEach
+    void createUsers50() {
+        Strategy strategy = null;
+        TradeType tradeType = new TradeType(1L, "파괴적",true,"asdf.jpg");
+
+        tradeTypeRepository.save(tradeType);
+
+        for (int i = 0; i < 50; i++) {
+
+            DecimalFormat dc = new DecimalFormat("##");
+
+            User user = User.builder().userName("정룡우" + i).nickname("jeongRyongWoo" + i)
+                    .email("jlwoo0925" + i + "@gmail.com").password("asdf" + i)
+                    .imageUrl("jrw_projectS3/profile/정룡우.img").phone("010123456" + dc.format(i)).birthDate("000925")
+                    .ipAddress("127.0.0.1").infoAgreement(Boolean.FALSE).userState(UserState.ACTIVE)
+                    .role(roles.get(i % 5)).build();
+
+            userRepository.save(user);
+
+            if (user.getRole() == Role.TRADER||user.getRole() == Role.TRADER_ADMIN) {
+                strategy = Strategy.builder().user(user).tradeType(tradeType).strategyName("전략" + i).isPublic(IsPublic.PUBLIC)
+                        .isApproved(IsApproved.APPROVED).build();
+
+                strategyRepository.save(strategy);
+            }
+
+            if(strategy != null) {
+                 Subscription subscription = Subscription.builder().user(user).strategy(strategy).build();
+                 subscriptionRepository.save(subscription);
+            }
+
+        }
+    }
+
+
+    @Test
+    @DisplayName("트레이더 목록 조회 테스트.")
+    void TraderListRepositoryTest1() {
+        //구독순 확인.
+        Pageable pageable = PageRequest.of(0, 4);
+        Page<TraderProfileDto> page =userRepository.getTraderListPage(null,null,pageable);
+        for (TraderProfileDto traderProfileDto : page.getContent()) {
+            System.out.println(traderProfileDto);
+        }
+    }
+
+}

--- a/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
@@ -18,6 +18,7 @@ import com.investmetic.domain.user.model.entity.User;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,6 +94,14 @@ class TraderListRepositoryTest {
             }
 
         }
+    }
+    @AfterAll
+    void deleteAll(){
+        //constraint -> 연관 관계 순서대로
+        subscriptionRepository.deleteAll();
+        strategyRepository.deleteAll();
+        tradeTypeRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
 
@@ -213,3 +222,4 @@ class TraderListRepositoryTest {
 
 
 }
+

--- a/src/test/java/com/investmetic/domain/user/service/AdminPageUserServiceTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/AdminPageUserServiceTest.java
@@ -38,6 +38,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("관리자 회원 페이지")
 public class AdminPageUserServiceTest {
 
     @Mock

--- a/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
@@ -1,0 +1,75 @@
+package com.investmetic.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.investmetic.domain.user.dto.response.TraderProfileDto;
+import com.investmetic.domain.user.repository.UserRepository;
+import com.investmetic.global.exception.BusinessException;
+import com.investmetic.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DisplayName("트레이더 조회 목록 기능")
+@ExtendWith(MockitoExtension.class)
+class TraderListTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+
+    @Test
+    @DisplayName("")
+    void traderListTest1() {
+        // given
+        Pageable pageable = PageRequest.of(0, 12);
+        String orderBy = null;
+        String keyword = null;
+
+        List<TraderProfileDto> list = new ArrayList<>();
+        TraderProfileDto traderProfileDto = new TraderProfileDto(1, "userName", "nickname", "imageUrl", 4L, 100L);
+        list.add(traderProfileDto);
+
+        // size가 1인 목록 반환.
+        when(userRepository.getTraderListPage(orderBy, keyword, pageable)).thenReturn(new PageImpl<>(list));
+
+        // when, then 아무런 에러도 없어야함.
+        assertThatCode(() -> userRepository.getTraderListPage(orderBy, keyword, pageable)).doesNotThrowAnyException();
+
+
+    }
+
+    @Test
+    @DisplayName("트레이더 조회 목록 size가 0일때.")
+    void traderListTest2() {
+
+        // given
+        Pageable pageable = PageRequest.of(0, 12);
+        String orderBy = null;
+        String keyword = null;
+
+        List<TraderProfileDto> list = new ArrayList<>();
+
+        // size가 0인 목록 반환
+        when(userRepository.getTraderListPage(orderBy, keyword, pageable)).thenReturn(new PageImpl<>(list));
+
+        // when, then - throw BusinessException
+        assertThatThrownBy(() -> userService.getTraderList(orderBy, keyword, pageable)).isInstanceOf(
+                BusinessException.class).hasMessage(ErrorCode.TRADER_LIST_RETRIEVAL_FAILED.getMessage());
+
+    }
+
+}

--- a/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
@@ -40,7 +40,7 @@ class TraderListTest {
         String keyword = null;
 
         List<TraderProfileDto> list = new ArrayList<>();
-        TraderProfileDto traderProfileDto = new TraderProfileDto(1, "userName", "nickname", "imageUrl", 4L, 100);
+        TraderProfileDto traderProfileDto = new TraderProfileDto(1L, "userName", "nickname", "imageUrl", 4L, 100);
         list.add(traderProfileDto);
 
         // size가 1인 목록 반환.

--- a/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
@@ -32,7 +32,7 @@ class TraderListTest {
 
 
     @Test
-    @DisplayName("")
+    @DisplayName("트레이더 목록 조회 정상")
     void traderListTest1() {
         // given
         Pageable pageable = PageRequest.of(0, 12);
@@ -40,7 +40,7 @@ class TraderListTest {
         String keyword = null;
 
         List<TraderProfileDto> list = new ArrayList<>();
-        TraderProfileDto traderProfileDto = new TraderProfileDto(1, "userName", "nickname", "imageUrl", 4L, 100L);
+        TraderProfileDto traderProfileDto = new TraderProfileDto(1, "userName", "nickname", "imageUrl", 4L, 100);
         list.add(traderProfileDto);
 
         // size가 1인 목록 반환.

--- a/src/test/java/com/investmetic/domain/user/service/UserMyPageServiceTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/UserMyPageServiceTest.java
@@ -43,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional
 @Import(S3MockConfig.class)
+@DisplayName("회원 마이페이지 Service")
 class UserMyPageServiceTest {
 
     private static final String BUCKET_NAME = "fastcampus-team3";


### PR DESCRIPTION
## 📌 PR 개요
- 트레이더 목록 조회 기능

## #️⃣연관된 이슈

> #26

## 📝작업 내용

- 트레이더 목록 조회 기능

정렬 - 구독수순, 전략수순
조건 검색 - 닉네임에 대해서만

 페이지 입장시에 구독 순으로 정렬되어 옵니다.
트레이더 id, 트레이더 이름, 트레이더 닉네임, 트레이더 이미지 url, 트레이더 총 전략수, 트레이더 전략의 총 구독수

orderBy, Keyword 에 null 가능
orderBy에는 STRATEGY_TOTAL을 넣으면 전략수 순으로 정렬됨.