### PR TITLE
Feat/mypage strategies #104

### DIFF
--- a/src/main/java/com/investmetic/domain/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/review/dto/response/ReviewDetailResponse.java
@@ -17,19 +17,16 @@ public class ReviewDetailResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     private final int starRating;
-    private final Boolean isOwner;
 
     // 정적 팩토리 메서드
     public static ReviewDetailResponse from(Review review, User user) {
-        boolean isOwner = review.getUser().equals(user);
         return new ReviewDetailResponse(
                 review.getReviewId(),
                 review.getNickname(),
                 review.getContent(),
                 user.getImageUrl(),
                 review.getCreatedAt(),
-                review.getStarRating(),
-                isOwner
+                review.getStarRating()
         );
     }
 }

--- a/src/main/java/com/investmetic/domain/review/dto/response/ReviewListResponse.java
+++ b/src/main/java/com/investmetic/domain/review/dto/response/ReviewListResponse.java
@@ -9,13 +9,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewListResponse {
     private final double averageRating;
-    private final int reviewCount;
     private final PageResponseDto<ReviewDetailResponse> reviews;
 
     // 정적 팩토리 메서드
-    public static ReviewListResponse createReviewListResponse(double averageRating,int reviewCount,
+    public static ReviewListResponse createReviewListResponse(double averageRating,
                                                               PageResponseDto<ReviewDetailResponse> reviews) {
-        return new ReviewListResponse(RoundUtil.roundToSecond(averageRating), reviewCount,reviews);
+        return new ReviewListResponse(RoundUtil.roundToSecond(averageRating),reviews);
     }
 
 }

--- a/src/main/java/com/investmetic/domain/review/service/ReviewService.java
+++ b/src/main/java/com/investmetic/domain/review/service/ReviewService.java
@@ -139,7 +139,6 @@ public class ReviewService {
 
         PageResponseDto<ReviewDetailResponse> responsePageResponseDto = new PageResponseDto<>(reviews);
 
-        return ReviewListResponse.createReviewListResponse(strategy.getAverageRating(), strategy.getReviewCount(),
-                responsePageResponseDto);
+        return ReviewListResponse.createReviewListResponse(strategy.getAverageRating(), responsePageResponseDto);
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -5,6 +5,7 @@ import com.investmetic.domain.strategy.dto.request.TraderDailyAnalysisRequestDto
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
 import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
 import com.investmetic.domain.strategy.dto.response.StrategyModifyInfoResponseDto;
+import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
 import com.investmetic.domain.strategy.service.StrategyAnalysisService;
 import com.investmetic.domain.strategy.service.StrategyListingService;
 import com.investmetic.domain.strategy.service.StrategyRegisterService;
@@ -120,9 +121,20 @@ public class StrategyController {
     @Operation(summary = "트레이더 나의 전략목록 조회(마이페이지) ",
             description = "<a href='https://www.notion.so/2ddd1d0be73a47a7a683394d77943b20' target='_blank'>API 명세서</a>")
     @GetMapping
-    public ResponseEntity<BaseResponse<PageResponseDto<MyStrategySimpleResponse>>> searchByFilters(
+    public ResponseEntity<BaseResponse<PageResponseDto<MyStrategySimpleResponse>>> getMyStrategies(
             @RequestParam Long userId,
             @PageableDefault(size = 4) Pageable pageable) {
         return BaseResponse.success(strategyListingService.getMyStrategies(userId,pageable));
     }
+
+    //TODO : 스프링 시큐리티 적용시 수정
+    @Operation(summary = "구독한 전략목록 조회(마이페이지) ",
+            description = "<a href='https://www.notion.so/5a2dd36508804ca8945692d269c47710' target='_blank'>API 명세서</a>")
+    @GetMapping("/subscribed")
+    public ResponseEntity<BaseResponse<PageResponseDto<StrategySimpleResponse>>> getSubscribedStrategies(
+            @RequestParam Long userId,
+            @PageableDefault(size = 8) Pageable pageable) {
+        return BaseResponse.success(strategyListingService.getSubscribedStrategies(userId,pageable));
+    }
+
 }

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -3,11 +3,13 @@ package com.investmetic.domain.strategy.controller;
 import com.investmetic.domain.strategy.dto.StrategyRegisterRequestDto;
 import com.investmetic.domain.strategy.dto.request.TraderDailyAnalysisRequestDto;
 import com.investmetic.domain.strategy.dto.response.DailyAnalysisResponse;
+import com.investmetic.domain.strategy.dto.response.MyStrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
 import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
 import com.investmetic.domain.strategy.dto.response.StrategyModifyInfoResponseDto;
 import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
 import com.investmetic.domain.strategy.service.StrategyAnalysisService;
+import com.investmetic.domain.strategy.service.StrategyDetailService;
 import com.investmetic.domain.strategy.service.StrategyListingService;
 import com.investmetic.domain.strategy.service.StrategyRegisterService;
 import com.investmetic.domain.strategy.service.StrategyService;
@@ -46,6 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StrategyController {
     private final StrategyRegisterService strategyRegisterService;
     private final StrategyAnalysisService strategyAnalysisService;
+    private final StrategyDetailService strategyDetailService;
     private final StrategyService strategyService;
     private final StrategyListingService strategyListingService;
 
@@ -146,6 +149,14 @@ public class StrategyController {
             @PathVariable Long strategyId,
             @PageableDefault(size = 5, sort = "dailyDate", direction = Direction.DESC) Pageable pageable) {
         return BaseResponse.success(strategyAnalysisService.getMyDailyAnalysis(strategyId, pageable));
+    }
+
+    @Operation(summary = "나의 전략 기본정보 조회(마이페이지) ",
+            description = "<a href='https://www.notion.so/445709f04679440cbd729c6cabf64f0c' target='_blank'>API 명세서</a>")
+    @GetMapping("/{strategyId}")
+    public ResponseEntity<BaseResponse<MyStrategyDetailResponse>> getMyStrategiesDetail(
+            @PathVariable Long strategyId) {
+        return BaseResponse.success(strategyDetailService.getMyStrategyDetail(strategyId));
     }
 
 }

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -2,6 +2,7 @@ package com.investmetic.domain.strategy.controller;
 
 import com.investmetic.domain.strategy.dto.StrategyRegisterRequestDto;
 import com.investmetic.domain.strategy.dto.request.TraderDailyAnalysisRequestDto;
+import com.investmetic.domain.strategy.dto.response.DailyAnalysisResponse;
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
 import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
 import com.investmetic.domain.strategy.dto.response.StrategyModifyInfoResponseDto;
@@ -124,7 +125,7 @@ public class StrategyController {
     public ResponseEntity<BaseResponse<PageResponseDto<MyStrategySimpleResponse>>> getMyStrategies(
             @RequestParam Long userId,
             @PageableDefault(size = 4) Pageable pageable) {
-        return BaseResponse.success(strategyListingService.getMyStrategies(userId,pageable));
+        return BaseResponse.success(strategyListingService.getMyStrategies(userId, pageable));
     }
 
     //TODO : 스프링 시큐리티 적용시 수정
@@ -134,7 +135,17 @@ public class StrategyController {
     public ResponseEntity<BaseResponse<PageResponseDto<StrategySimpleResponse>>> getSubscribedStrategies(
             @RequestParam Long userId,
             @PageableDefault(size = 8) Pageable pageable) {
-        return BaseResponse.success(strategyListingService.getSubscribedStrategies(userId,pageable));
+        return BaseResponse.success(strategyListingService.getSubscribedStrategies(userId, pageable));
+    }
+
+    //TODO : 스프링 시큐리티 적용시 수정
+    @Operation(summary = "나의 전략 일간분석 조회(마이페이지) ",
+            description = "<a href='https://www.notion.so/445709f04679440cbd729c6cabf64f0c' target='_blank'>API 명세서</a>")
+    @GetMapping("/{strategyId}/daily-analysis")
+    public ResponseEntity<BaseResponse<PageResponseDto<DailyAnalysisResponse>>> getMyDailyAnalysis(
+            @PathVariable Long strategyId,
+            @PageableDefault(size = 5, sort = "dailyDate", direction = Direction.DESC) Pageable pageable) {
+        return BaseResponse.success(strategyAnalysisService.getMyDailyAnalysis(strategyId, pageable));
     }
 
 }

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyDetailController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyDetailController.java
@@ -5,7 +5,7 @@ import com.investmetic.domain.strategy.dto.response.MonthlyAnalysisResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyAnalysisResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.statistic.StrategyStatisticsResponse;
-import com.investmetic.domain.strategy.exceldownload.ExcelUtils;
+import com.investmetic.global.util.exceldownload.ExcelUtils;
 import com.investmetic.domain.strategy.model.AnalysisOption;
 import com.investmetic.domain.strategy.service.StrategyDetailService;
 import com.investmetic.global.common.PageResponseDto;

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyRankingController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyRankingController.java
@@ -1,11 +1,9 @@
 package com.investmetic.domain.strategy.controller;
 
-import com.investmetic.domain.strategy.dto.request.FilterSearchRequest;
-import com.investmetic.domain.strategy.dto.response.RegisterInfoResponseDto;
+import com.investmetic.domain.strategy.dto.request.SearchRequest;
+import com.investmetic.domain.strategy.dto.response.SearchInfoResponseDto;
 import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
-import com.investmetic.domain.strategy.model.AlgorithmType;
 import com.investmetic.domain.strategy.service.StrategyListingService;
-import com.investmetic.domain.strategy.service.StrategyRegisterService;
 import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.exception.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,43 +27,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/strategies/search")
 @Tag(name = "전략 랭킹페이지 API", description = "전략 랭킹페이지 관련 API")
 public class StrategyRankingController {
+
     private final StrategyListingService strategyListingService;
-    private final StrategyRegisterService strategyRegisterService;
 
-    @Operation(summary = "전략 항목별 검색(전략 랭킹페이지) ",
-            description = "<a href='https://www.notion.so/d547c3ca558d42239f45ddf4e40e113d' target='_blank'>API 명세서</a>")
-    @PostMapping("/filters")
-    public ResponseEntity<BaseResponse<PageResponseDto<StrategySimpleResponse>>> searchByFilters(
-            @RequestBody FilterSearchRequest filterSearchRequest,
-            @RequestParam Long userId,
-            @PageableDefault(size = 8, sort = "cumulativeProfitRate", direction = Direction.DESC) Pageable pageable) {
-        PageResponseDto<StrategySimpleResponse> result = strategyListingService.searchByFilters(
-                filterSearchRequest, userId, pageable);
-
-        return BaseResponse.success(result);
-    }
-
-    @Operation(summary = "전략 알고리즘별 검색(전략 랭킹페이지) ",
-            description = "<a href='https://www.notion.so/10dad66378804aedb83e9672ea419329' target='_blank'>API 명세서</a>")
-    @GetMapping("/algorithm")
-    public ResponseEntity<BaseResponse<PageResponseDto<StrategySimpleResponse>>> searchByAlgorithm(
-            @RequestParam(required = false) String searchWord,
-            @RequestParam(required = false) AlgorithmType algorithmType,
-            @RequestParam Long userId,
-            @PageableDefault(size = 8, sort = "cumulativeProfitRate", direction = Direction.DESC) Pageable pageable) {
-        PageResponseDto<StrategySimpleResponse> result = strategyListingService
-                .searchByAlgorithm(searchWord, algorithmType, userId, pageable);
-
-        return BaseResponse.success(result);
-    }
-
-
-    // 랭킹 페이지 진입시 요청
     @Operation(summary = "전략 랭킹페이지 진입시 요청(매매유형, 종목 조회) ",
             description = "<a href='https://www.notion.so/6737234016814bd2bbee79e49cc652c8' target='_blank'>API 명세서</a>")
     @GetMapping
-    public ResponseEntity<BaseResponse<RegisterInfoResponseDto>> loadStrategyRegistrationInfo() {
-        return BaseResponse.success(strategyRegisterService.loadStrategyRegistrationInfo());
+    public ResponseEntity<BaseResponse<SearchInfoResponseDto>> loadSearchInfo() {
+        return BaseResponse.success(strategyListingService.loadSearchInfo());
+    }
+
+    @Operation(summary = "항목 및 알고리즘별 복합 검색(전략 랭킹페이지) ",
+            description = "<a href='https://www.notion.so/e40465111e1b4ab2af76849ac76b04b9' target='_blank'>API 명세서</a>")
+    @PostMapping
+    public ResponseEntity<BaseResponse<PageResponseDto<StrategySimpleResponse>>> search(
+            @RequestBody SearchRequest searchRequest,
+            @RequestParam Long userId,
+            @PageableDefault(size = 8, sort = "cumulativeProfitRate", direction = Direction.DESC) Pageable pageable) {
+        PageResponseDto<StrategySimpleResponse> result = strategyListingService
+                .search(searchRequest, userId, pageable);
+        return BaseResponse.success(result);
     }
 
 }

--- a/src/main/java/com/investmetic/domain/strategy/dto/request/SearchRequest.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/request/SearchRequest.java
@@ -1,0 +1,23 @@
+package com.investmetic.domain.strategy.dto.request;
+
+import com.investmetic.domain.strategy.dto.RangeDto;
+import com.investmetic.domain.strategy.model.AlgorithmType;
+import com.investmetic.domain.strategy.model.DurationRange;
+import com.investmetic.domain.strategy.model.OperationCycle;
+import com.investmetic.domain.strategy.model.ProfitRange;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SearchRequest {
+    private String searchWord; // 검색어
+    private List<String> tradeTypeNames; // 매매방식 이름
+    private List<OperationCycle> operationCycles; // 운용주기
+    private List<String> stockTypeNames; // 운용 종목 이름
+    private List<DurationRange> durations; // 기간 (1년 이하, 1~2년 등)
+    private List<ProfitRange> profitRanges; // 수익률 범위
+    private RangeDto principalRange; // 원금 범위
+    private RangeDto mddRange; // MDD 범위
+    private RangeDto smScoreRange; // SM SCORE 범위
+    private AlgorithmType algorithmType; // 알고리즘 타입
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/DailyAnalysisResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/DailyAnalysisResponse.java
@@ -1,8 +1,8 @@
 package com.investmetic.domain.strategy.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.investmetic.domain.strategy.exceldownload.ExcelColumn;
-import com.investmetic.domain.strategy.exceldownload.ExcelSheet;
+import com.investmetic.global.util.exceldownload.ExcelColumn;
+import com.investmetic.global.util.exceldownload.ExcelSheet;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDate;
 import lombok.Getter;

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/MonthlyAnalysisResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/MonthlyAnalysisResponse.java
@@ -1,8 +1,8 @@
 package com.investmetic.domain.strategy.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.investmetic.domain.strategy.exceldownload.ExcelColumn;
-import com.investmetic.domain.strategy.exceldownload.ExcelSheet;
+import com.investmetic.global.util.exceldownload.ExcelColumn;
+import com.investmetic.global.util.exceldownload.ExcelSheet;
 import com.investmetic.domain.strategy.model.entity.MonthlyAnalysis;
 import java.time.format.DateTimeFormatter;
 import lombok.Getter;

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/MyStrategyDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/MyStrategyDetailResponse.java
@@ -1,0 +1,66 @@
+package com.investmetic.domain.strategy.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.investmetic.domain.strategy.model.IsApproved;
+import com.investmetic.domain.strategy.model.IsPublic;
+import com.investmetic.domain.strategy.model.MinimumInvestmentAmount;
+import com.investmetic.domain.strategy.model.OperationCycle;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MyStrategyDetailResponse {
+
+    private String strategyName;                    // 전략명
+    private List<String> stockTypeIconURLs;         // 종목 아이콘 이미지 경로 리스트
+    private List<String> stockTypeNames;            // 종목 이름 리스트
+    private String tradeTypeIconURL;                // 매매 유형 이미지 경로
+    private String tradeTypeName;                   // 투자 종류 (자동, 반자동, 수동)
+    private OperationCycle operationCycle;          // 투자 주기 (데이, 포지션)
+    private String strategyDescription;             // 전략 상세 소개
+    private int subscriptionCount;                  // 구독 수
+    private String traderImgUrl;                    // 트레이더 프로필 이미지
+    private String nickname;                        // 트레이더 이름
+    private String minimumInvestmentAmount;         // 최소 운용 금액
+    private long initialInvestment;                 // 투자 원금
+    private double kpRatio;                         // KP 비율
+    private double smScore;                         // SM 점수
+    private LocalDate finalProfitLossDate;          // 최종 손익 입력 일자
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;                    // 전략 등록일
+    private IsPublic isPublic;                      // 공개여부
+    private IsApproved isApproved;                  // 승인여부
+
+
+    @QueryProjection
+    public MyStrategyDetailResponse(String strategyName, List<String> stockTypeIconURLs, String tradeTypeIconURL,
+                                    List<String> stockTypeNames, String tradeTypeName, OperationCycle operationCycle,
+                                    String strategyDescription, int subscriptionCount, String traderImgUrl,
+                                    String nickname, MinimumInvestmentAmount minimumInvestmentAmount,
+                                    long initialInvestment, double kpRatio, double smScore,
+                                    LocalDate finalProfitLossDate, LocalDateTime createdAt, IsPublic isPublic,
+                                    IsApproved isApproved) {
+        this.strategyName = strategyName;
+        this.stockTypeIconURLs = stockTypeIconURLs;
+        this.tradeTypeIconURL = tradeTypeIconURL;
+        this.stockTypeNames = stockTypeNames;
+        this.tradeTypeName = tradeTypeName;
+        this.operationCycle = operationCycle;
+        this.strategyDescription = strategyDescription;
+        this.subscriptionCount = subscriptionCount;
+        this.traderImgUrl = traderImgUrl;
+        this.nickname = nickname;
+        this.minimumInvestmentAmount = minimumInvestmentAmount.getDescription();
+        this.initialInvestment = initialInvestment;
+        this.kpRatio = kpRatio;
+        this.smScore = smScore;
+        this.finalProfitLossDate = finalProfitLossDate;
+        this.createdAt = createdAt;
+        this.isPublic = isPublic;
+        this.isApproved = isApproved;
+    }
+
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/SearchInfoResponseDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/SearchInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.investmetic.domain.strategy.dto.response;
+
+import com.investmetic.domain.strategy.model.entity.StockType;
+import com.investmetic.domain.strategy.model.entity.TradeType;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SearchInfoResponseDto {
+    private final List<String> stockTypeNames;
+    private final List<String> tradeTypeNames;
+
+    public static SearchInfoResponseDto from(List<StockType> stockTypeNames, List<TradeType> tradeTypeNames) {
+        return new SearchInfoResponseDto(
+                stockTypeNames.stream()
+                        .map(StockType::getStockTypeName)
+                        .toList(),
+                tradeTypeNames.stream()
+                        .map(TradeType::getTradeTypeName)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyDetailResponse.java
@@ -15,18 +15,18 @@ public class StrategyDetailResponse {
     private String strategyName;                    // 전략명
     private List<String> stockTypeIconURLs;         // 종목 아이콘 이미지 경로 리스트
     private List<String> stockTypeNames;            // 종목 이름 리스트
-    private String tradeTypeIconURL;                   // 매매 유형 이미지 경로
+    private String tradeTypeIconURL;                // 매매 유형 이미지 경로
     private String tradeTypeName;                   // 투자 종류 (자동, 반자동, 수동)
-    private OperationCycle operationCycle;         // 투자 주기 (데이, 포지션)
+    private OperationCycle operationCycle;          // 투자 주기 (데이, 포지션)
     private String strategyDescription;             // 전략 상세 소개
     private double cumulativeProfitRate;            // 누적 수익률
-    private double maxDrawdownRate;                 // 최대 자본 인하율
+    private double maxDrawdownRate;                 // 최대 자본 인하율(MDD)
     private double averageProfitLossRate;           // 평균 손익률
     private double profitFactor;                    // Profit Factor
     private double winRate;                         // 승률
     private int subscriptionCount;                  // 구독 수
     private Boolean isSubscribed;                   // 구독 여부
-    private String traderImgUrl;                        // 트레이더 프로필 이미지
+    private String traderImgUrl;                    // 트레이더 프로필 이미지
     private String nickname;                        // 트레이더 이름
     private String minimumInvestmentAmount;         // 최소 운용 금액
     private long initialInvestment;                 // 투자 원금

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/common/MyStrategySimpleResponse.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/common/MyStrategySimpleResponse.java
@@ -1,17 +1,21 @@
 package com.investmetic.domain.strategy.dto.response.common;
 
+import com.investmetic.domain.strategy.model.IsPublic;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 @Getter
 public class MyStrategySimpleResponse extends BaseStrategyResponse {
 
+    private IsPublic isPublic;
+
     @QueryProjection
     public MyStrategySimpleResponse(Long strategyId, String strategyName, String traderImgUrl, String nickname,
                                     String tradeTypeIconUrl, long mdd, double smScore,
                                     double cumulativeProfitRate, double recentYearProfitLossRate, int subscriptionCount,
-                                    double averageRating, int totalReviews) {
+                                    double averageRating, int totalReviews, IsPublic isPublic) {
         super(strategyId, strategyName, traderImgUrl, nickname, tradeTypeIconUrl, mdd, smScore, cumulativeProfitRate,
                 recentYearProfitLossRate, subscriptionCount, averageRating, totalReviews);
+        this.isPublic = isPublic;
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/DailyAnalysis.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/DailyAnalysis.java
@@ -2,6 +2,8 @@ package com.investmetic.domain.strategy.model.entity;
 
 import com.investmetic.global.common.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -166,5 +168,6 @@ public class DailyAnalysis extends BaseEntity {
     private Double maxDrawDownInRate = 0.0; //
 
     @Builder.Default
-    private Boolean proceed = Boolean.TRUE; // 등록, 수정 시 False
+    @Enumerated(EnumType.STRING)
+    private Proceed proceed = Proceed.YES; // 등록, 수정 시 NO
 }

--- a/src/main/java/com/investmetic/domain/strategy/model/entity/Proceed.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/Proceed.java
@@ -1,0 +1,6 @@
+package com.investmetic.domain.strategy.model.entity;
+
+public enum Proceed {
+    YES,
+    NO
+}

--- a/src/main/java/com/investmetic/domain/strategy/repository/DailyAnalysisRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/DailyAnalysisRepository.java
@@ -12,12 +12,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface DailyAnalysisRepository extends JpaRepository<DailyAnalysis, Long>, DailyAnalysisRepositoryCustom {
 
-    @Query("SELECT d FROM DailyAnalysis d WHERE d.strategy = :strategy AND d.dailyDate = :dailyDate AND d.proceed = false")
+    @Query("SELECT d FROM DailyAnalysis d WHERE d.strategy = :strategy AND d.dailyDate = :dailyDate AND d.proceed = 'NO'")
     Optional<DailyAnalysis> findByStrategyAndDailyDateAndProceedIsFalse(
             @Param("strategy") Strategy strategy,
             @Param("dailyDate") LocalDate dailyDate);
 
-    @Query("SELECT d FROM DailyAnalysis d WHERE d.strategy = :strategy AND d.dailyDate = :dailyDate AND d.proceed = true")
+    @Query("SELECT d FROM DailyAnalysis d WHERE d.strategy = :strategy AND d.dailyDate = :dailyDate AND d.proceed = 'YES'")
     Optional<DailyAnalysis> findByStrategyAndDailyDateAndProceedIsTrue(
             @Param("strategy") Strategy strategy,
             @Param("dailyDate") LocalDate dailyDate);
@@ -49,16 +49,16 @@ public interface DailyAnalysisRepository extends JpaRepository<DailyAnalysis, Lo
     @Query("SELECT d FROM DailyAnalysis d WHERE d.strategy.strategyId = :strategyId ORDER BY d.dailyDate ASC")
     List<DailyAnalysis> findAllByStrategy(@Param("strategyId") Long strategyId);
 
-    @Query("SELECT d FROM DailyAnalysis d WHERE d.proceed = false")
+    @Query("SELECT d FROM DailyAnalysis d WHERE d.proceed = 'NO'")
     List<DailyAnalysis> findAllByProceedIsFalse();
 
     @Query("""
             SELECT d FROM DailyAnalysis d
-                WHERE d.proceed = false
+                WHERE d.proceed = 'NO'
                   AND d.dailyDate = (
                       SELECT MIN(d2.dailyDate) FROM DailyAnalysis d2
                       WHERE d2.strategy.strategyId = d.strategy.strategyId
-                        AND d2.proceed = false
+                        AND d2.proceed = 'NO'
                   )
                 ORDER BY d.dailyDate ASC
             """)

--- a/src/main/java/com/investmetic/domain/strategy/repository/DailyAnalysisRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/DailyAnalysisRepositoryCustom.java
@@ -17,4 +17,8 @@ public interface DailyAnalysisRepositoryCustom {
     Page<DailyAnalysisResponse> findByStrategyId(Long strategyId, Pageable pageable);
 
     List<DailyAnalysisResponse> findDailyAnalysisForExcel(Long strategyId);
+
+    Page<DailyAnalysisResponse> findMyDailyAnalysis(Long strategyId, Pageable pageable);
+
+
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
@@ -1,17 +1,21 @@
 package com.investmetic.domain.strategy.repository;
 
 import com.investmetic.domain.strategy.dto.request.SearchRequest;
+import com.investmetic.domain.strategy.dto.response.MyStrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
 import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
 import com.querydsl.core.Tuple;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StrategyRepositoryCustom {
-    StrategyDetailResponse findStrategyDetail(Long strategyId);
+    Optional<StrategyDetailResponse> findStrategyDetail(Long strategyId);
+
+    Optional<MyStrategyDetailResponse> findMyStrategyDetail(Long strategyId);
 
     Map<Long, List<String>> findStockTypeIconsMap(List<Long> strategyIdS);
 

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
@@ -26,5 +26,7 @@ public interface StrategyRepositoryCustom {
     Page<StrategySimpleResponse> searchByAlgorithm(String searchWord, AlgorithmType algorithmType, Pageable pageable);
 
     Page<MyStrategySimpleResponse> findMyStrategies(Long userId,Pageable pageable);
+
+    Page<StrategySimpleResponse> findSubscribedStrategies(Long userId,Pageable pageable);
 }
 

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
@@ -1,11 +1,9 @@
 package com.investmetic.domain.strategy.repository;
 
-import com.investmetic.domain.strategy.dto.request.AlgorithmSearchRequest;
-import com.investmetic.domain.strategy.dto.request.FilterSearchRequest;
-import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
+import com.investmetic.domain.strategy.dto.request.SearchRequest;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
+import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
 import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
-import com.investmetic.domain.strategy.model.AlgorithmType;
 import com.querydsl.core.Tuple;
 import java.util.List;
 import java.util.Map;
@@ -21,12 +19,11 @@ public interface StrategyRepositoryCustom {
 
     Map<Long, Boolean> findBySubscriptionMap(Long userId, List<Long> strategyIdS);
 
-    Page<StrategySimpleResponse> searchByFilters(FilterSearchRequest filterSearchRequest, Pageable pageable);
+    Page<StrategySimpleResponse> searchBy(SearchRequest searchRequest, Pageable pageable);
 
-    Page<StrategySimpleResponse> searchByAlgorithm(String searchWord, AlgorithmType algorithmType, Pageable pageable);
+    Page<MyStrategySimpleResponse> findMyStrategies(Long userId, Pageable pageable);
 
-    Page<MyStrategySimpleResponse> findMyStrategies(Long userId,Pageable pageable);
+    Page<StrategySimpleResponse> findSubscribedStrategies(Long userId, Pageable pageable);
 
-    Page<StrategySimpleResponse> findSubscribedStrategies(Long userId,Pageable pageable);
 }
 

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustomImpl.java
@@ -11,8 +11,7 @@ import static com.investmetic.domain.subscription.model.entity.QSubscription.sub
 import static com.investmetic.domain.user.model.entity.QUser.user;
 
 import com.investmetic.domain.strategy.dto.RangeDto;
-import com.investmetic.domain.strategy.dto.request.AlgorithmSearchRequest;
-import com.investmetic.domain.strategy.dto.request.FilterSearchRequest;
+import com.investmetic.domain.strategy.dto.request.SearchRequest;
 import com.investmetic.domain.strategy.dto.response.QStrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
@@ -48,7 +47,6 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
 public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
-
     private final JPAQueryFactory queryFactory;
 
 
@@ -106,16 +104,14 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
     }
 
     /***
-     * 항목별 검색 조회 쿼리(운용방식, 운용주기, 운용종목, 기간, 수익률, 원금, MDD, SM Score로 검색)
-     * 각 항목들은 중복 체크가 가능
-     * 공개중인 전략과 승인완료된 전략만 조회가능
-     * 수익률로 정렬
-     * 페이징
+     * - 항목 및 알고리즘 검색 조회 동적쿼리(운용방식, 운용주기, 운용종목, 기간, 수익률, 원금, MDD, SM Score, 알고리즘별 로 검색) <br>
+     * - 검색어는 전략명으로 검색  <br>
+     * - 공개중인 전략과 승인완료된 전략만 조회가능 <br>
+     * - 기본은 수익률로 정렬, 알고리즘 선택시 알고리즘별로 정렬 <br>
+     * - 페이징 <br>
      */
     @Override
-    public Page<StrategySimpleResponse> searchByFilters(FilterSearchRequest request,
-                                                        Pageable pageable) {
-
+    public Page<StrategySimpleResponse> searchBy(SearchRequest searchRequest, Pageable pageable) {
         List<StrategySimpleResponse> content = queryFactory
                 .select(new QStrategySimpleResponse(
                         strategy.strategyId,
@@ -135,8 +131,8 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
                 .join(strategy.strategyStatistics, strategyStatistics)
                 .join(strategy.tradeType, tradeType)
                 .join(strategy.user, user)
-                .where(isApprovedAndPublic(), applyAllFilters(request))
-                .orderBy(strategyStatistics.cumulativeProfitRate.desc()) // 누적수익률으로 정렬
+                .where(isApprovedAndPublic(), applyAllFilters(searchRequest))
+                .orderBy(getOrderByAlgorithm(searchRequest.getAlgorithmType())) // 알고리즘 타입으로 정렬
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -145,53 +141,7 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(Wildcard.count)
                 .from(strategy)
-                .where(isApprovedAndPublic(), applyAllFilters(request));
-
-        // 만약 페이지의 처음이나, 끝일때, 전체 데이터 크기가 pageSize보다 작은 경우 COUNT 쿼리가 실행되지 않음
-        // 그 외 경우에만 fetchOne() 을 실행하여 전체 데이터 개수를 계산
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
-    }
-
-    /***
-     * 검색어(전략명) + 알고리즘 검색
-     * 알고리즘은 중복체크 X, 알고리즘별로 정렬
-     * 공개중인 전략과 승인완료된 전략만 조회가능
-     * 페이징
-     */
-    @Override
-    public Page<StrategySimpleResponse> searchByAlgorithm(String searchWord, AlgorithmType algorithmType,
-                                                          Pageable pageable) {
-
-        List<StrategySimpleResponse> content = queryFactory
-                .select(new QStrategySimpleResponse(
-                        strategy.strategyId,
-                        strategy.strategyName,
-                        user.imageUrl,
-                        user.nickname,
-                        tradeType.tradeTypeIconURL,
-                        strategyStatistics.maxDrawdown,
-                        strategyStatistics.smScore,
-                        strategyStatistics.cumulativeProfitRate,
-                        strategyStatistics.recentYearProfitRate,
-                        strategy.subscriptionCount,
-                        strategy.averageRating,
-                        strategy.reviewCount
-                ))
-                .from(strategy)
-                .join(strategy.strategyStatistics, strategyStatistics)
-                .join(strategy.tradeType, tradeType)
-                .join(strategy.user, user)
-                .where(isApprovedAndPublic(), applySearchWordFilter(searchWord))
-                .orderBy(getOrderByAlgorithm(algorithmType)) // 알고리즘별로 정렬
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        // 페이징 count 쿼리 최적화
-        JPAQuery<Long> countQuery = queryFactory
-                .select(Wildcard.count)
-                .from(strategy)
-                .where(isApprovedAndPublic(), applySearchWordFilter(searchWord));
+                .where(isApprovedAndPublic(), applyAllFilters(searchRequest));
 
         // 만약 페이지의 처음이나, 끝일때, 전체 데이터 크기가 pageSize보다 작은 경우 COUNT 쿼리가 실행되지 않음
         // 그 외 경우에만 fetchOne() 을 실행하여 전체 데이터 개수를 계산
@@ -199,7 +149,7 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
     }
 
     /**
-     * 나의 전략목록 조회(트레이더), 구독 많은수로 정렬
+     * 나의 전략목록 조회(트레이더), 최신순 정렬
      *
      * @param userId 로그인한 트레이더 id
      */
@@ -226,7 +176,7 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
                 .join(strategy.tradeType, tradeType)
                 .join(strategy.user, user)
                 .where(user.userId.eq(userId))
-                .orderBy(strategy.subscriptionCount.desc()) // 구독많은수로 정렬
+                .orderBy(strategy.createdAt.desc()) // 최신순으로 정렬
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -344,23 +294,22 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
     }
 
     // 모든 필터 적용
-    private BooleanBuilder applyAllFilters(FilterSearchRequest filterSearchRequest) {
+    private BooleanBuilder applyAllFilters(SearchRequest searchRequest) {
         BooleanBuilder builder = new BooleanBuilder();
 
         // 조건 추가
-        builder.and(applySearchWordFilter(filterSearchRequest.getSearchWord()));
-        builder.and(applyTradeTypeFilter(filterSearchRequest.getTradeTypeNames()));
-        builder.and(applyOperationCycleFilter(filterSearchRequest.getOperationCycles()));
-        builder.and(applyStockTypeFilter(filterSearchRequest.getStockTypeNames()));
-        builder.and(applyOperationPeriodFilter(filterSearchRequest.getDurations()));
-        builder.and(applyProfitRangeFilter(filterSearchRequest.getProfitRanges()));
-        builder.and(applyPrincipalRangeFilter(filterSearchRequest.getPrincipalRange()));
-        builder.and(applyMddRangeFilter(filterSearchRequest.getMddRange()));
-        builder.and(applySmScoreRangeFilter(filterSearchRequest.getSmScoreRange()));
+        builder.and(applySearchWordFilter(searchRequest.getSearchWord()));
+        builder.and(applyTradeTypeFilter(searchRequest.getTradeTypeNames()));
+        builder.and(applyOperationCycleFilter(searchRequest.getOperationCycles()));
+        builder.and(applyStockTypeFilter(searchRequest.getStockTypeNames()));
+        builder.and(applyOperationPeriodFilter(searchRequest.getDurations()));
+        builder.and(applyProfitRangeFilter(searchRequest.getProfitRanges()));
+        builder.and(applyPrincipalRangeFilter(searchRequest.getPrincipalRange()));
+        builder.and(applyMddRangeFilter(searchRequest.getMddRange()));
+        builder.and(applySmScoreRangeFilter(searchRequest.getSmScoreRange()));
 
         return builder;
     }
-
 
     private BooleanExpression isApprovedAndPublic() {
         return strategy.isApproved.eq(IsApproved.APPROVED)

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyAnalysisService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyAnalysisService.java
@@ -1,15 +1,20 @@
 package com.investmetic.domain.strategy.service;
 
 import com.investmetic.domain.strategy.dto.request.TraderDailyAnalysisRequestDto;
+import com.investmetic.domain.strategy.dto.response.DailyAnalysisResponse;
 import com.investmetic.domain.strategy.model.entity.DailyAnalysis;
+import com.investmetic.domain.strategy.model.entity.Proceed;
 import com.investmetic.domain.strategy.model.entity.Strategy;
 import com.investmetic.domain.strategy.repository.DailyAnalysisRepository;
 import com.investmetic.domain.strategy.repository.StrategyRepository;
+import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +47,7 @@ public class StrategyAnalysisService {
                         .dailyDate(analysisRequest.getDate())
                         .transaction(analysisRequest.getTransaction())
                         .dailyProfitLoss(analysisRequest.getDailyProfitLoss())
-                        .proceed(false)
+                        .proceed(Proceed.NO)
                         .build();
 
                 dailyAnalysisRepository.save(dailyAnalysis);
@@ -63,5 +68,11 @@ public class StrategyAnalysisService {
     private Strategy findStrategyById(Long strategyId) {
         return strategyRepository.findById(strategyId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.STRATEGY_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<DailyAnalysisResponse> getMyDailyAnalysis(Long strategyId, Pageable pageable) {
+        Page<DailyAnalysisResponse> myDailyAnalysis = dailyAnalysisRepository.findMyDailyAnalysis(strategyId, pageable);
+        return new PageResponseDto<>(myDailyAnalysis);
     }
 }

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyDetailService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyDetailService.java
@@ -2,6 +2,7 @@ package com.investmetic.domain.strategy.service;
 
 import com.investmetic.domain.strategy.dto.response.DailyAnalysisResponse;
 import com.investmetic.domain.strategy.dto.response.MonthlyAnalysisResponse;
+import com.investmetic.domain.strategy.dto.response.MyStrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyAnalysisResponse;
 import com.investmetic.domain.strategy.dto.response.StrategyDetailResponse;
 import com.investmetic.domain.strategy.dto.response.statistic.StrategyStatisticsResponse;
@@ -62,16 +63,25 @@ public class StrategyDetailService {
         return new PageResponseDto<>(page);
     }
 
-    // 전략 상세 조회
+    // 전략 상세 조회 (전략 상세페이지)
     public StrategyDetailResponse getStrategyDetail(Long strategyId, Long userId) {
-        StrategyDetailResponse strategyDetail = strategyRepository.findStrategyDetail(strategyId);
+        StrategyDetailResponse strategyDetail = strategyRepository.findStrategyDetail(strategyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STRATEGY_NOT_FOUND));
 
         // 구독여부 체크
         boolean isSubscribed = subscriptionRepository.existsByStrategyIdAndUserId(strategyId, userId);
+
+        // 구독여부 업데이트
         strategyDetail.updateIsSubscribed(isSubscribed);
+
         return strategyDetail;
     }
 
+    // 나의 전략 상세 조회(마이페이지)
+    public MyStrategyDetailResponse getMyStrategyDetail(Long strategyId) {
+        return strategyRepository.findMyStrategyDetail(strategyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STRATEGY_NOT_FOUND));
+    }
 
     // 전략 분석 조회
     public StrategyAnalysisResponse getStrategyAnalysis(Long strategyId, AnalysisOption option1,

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyListingService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyListingService.java
@@ -19,7 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-//TODO : 조회 성능개선 필요
+//TODO : 조회 성능개선 예정
 @RequiredArgsConstructor
 @Service
 public class StrategyListingService {
@@ -27,60 +27,81 @@ public class StrategyListingService {
     private final StrategyRepository strategyRepository;
 
     /**
-     * 필터 기반 전략목록 조회 (구독 여부 포함)
+     * 필터 기반 전략목록 조회 - (구독 여부 포함)
      *
-     * @param request  전략 검색 필터 요청
+     * @param request  전략 검색필터 요청
      * @param userId   로그인한 유저id
      * @param pageable 페이징 정보
-     * @return
+     * @return : 전략 목록에 대한 페이지 응답
      */
     public PageResponseDto<StrategySimpleResponse> searchByFilters(FilterSearchRequest request, Long userId,
                                                                    Pageable pageable) {
         // 데이터 조회
         Page<StrategySimpleResponse> content = strategyRepository.searchByFilters(request, pageable);
-        return updateResponsesWithSubscription(userId, content);
+        Map<Long, Boolean> subscriptionMap = generateSubscriptionMap(userId, getStrategyIds(content));
+        return processStrategyResponses(content, subscriptionMap);
     }
 
     /**
-     * 알고리즘 기반 전략목록 조회(구독여부 포함)
+     * 알고리즘 기반 전략목록 조회 - (구독여부 포함)
      *
      * @param searchWord    검색어
      * @param algorithmType 알고리즘별 타입
      * @param userId        로그인한 유저id
      * @param pageable      페이징 정보
-     * @return
+     * @return 전략 목록에 대한 페이지 응답
      */
     public PageResponseDto<StrategySimpleResponse> searchByAlgorithm(String searchWord, AlgorithmType algorithmType,
                                                                      Long userId, Pageable pageable) {
         // 데이터 조회
         Page<StrategySimpleResponse> content = strategyRepository.searchByAlgorithm(searchWord, algorithmType,
                 pageable);
-        return updateResponsesWithSubscription(userId, content);
+        Map<Long, Boolean> subscriptionMap = generateSubscriptionMap(userId, getStrategyIds(content));
+        return processStrategyResponses(content, subscriptionMap);
     }
 
     /**
-     * 나의 전략목록 조회 (트레이더), 구독여부 미포함
+     * 나의 전략목록 조회 (트레이더) - 구독여부 미포함
      *
-     * @param userId   로그인한 트레이더 id
+     * @param userId   로그인한 트레이더 정보
      * @param pageable 페이징 정보
-     * @return
+     * @return 나의 전략 목록에 대한 페이지 응답
      */
     public PageResponseDto<MyStrategySimpleResponse> getMyStrategies(Long userId, Pageable pageable) {
         Page<MyStrategySimpleResponse> content = strategyRepository.findMyStrategies(userId, pageable);
-        return updateResponsesWithoutSubscription(userId, content);
+        return processStrategyResponses(content, null);
     }
 
-    private PageResponseDto<StrategySimpleResponse> updateResponsesWithSubscription(Long userId,
-                                                                                    Page<StrategySimpleResponse> content) {
+    /**
+     * 구독한 전략 목록 조회 - 구독여부 항상 true
+     *
+     * @param userId   : 로그인한 회원정보(트레이더, 투자자)
+     * @param pageable : 페이징 정보
+     * @return 구독한 전략 목록에 대한 페이지 응답
+     */
+    public PageResponseDto<StrategySimpleResponse> getSubscribedStrategies(Long userId, Pageable pageable) {
+        Page<StrategySimpleResponse> content = strategyRepository.findSubscribedStrategies(userId,
+                pageable);
+        Map<Long, Boolean> subscriptionMap = getStrategyIds(content).stream()
+                .collect(Collectors.toMap(id -> id, id -> true));
+        return processStrategyResponses(content, subscriptionMap);
+    }
+
+    /**
+     * 응답 데이터 공통 처리 로직
+     *
+     * @param content         : 조회된 전략 데이터
+     * @param subscriptionMap 구독 여부 데이터 (null일 경우 구독 여부 처리 안 함)
+     * @param <T>             전략 응답 타입 (StrategySimpleResponse 또는 MyStrategySimpleResponse)
+     */
+    private <T extends BaseStrategyResponse> PageResponseDto<T> processStrategyResponses(
+            Page<T> content, Map<Long, Boolean> subscriptionMap) {
         // 전략 ID 추출
         List<Long> strategyIds = getStrategyIds(content);
 
-        // 배치 쿼리를 통해 필요한 데이터 조회
+        // 각 전략 ID에 대한 배치 쿼리 조회 (성능개선)
         Map<Long, List<String>> stockTypeIconsMap = strategyRepository.findStockTypeIconsMap(strategyIds);
         Map<Long, List<Tuple>> profitRateDataMap = strategyRepository.findProfitRateDataMap(strategyIds);
-        Map<Long, Boolean> subscriptionMap = (userId != null)
-                ? strategyRepository.findBySubscriptionMap(userId, strategyIds)
-                : strategyIds.stream().collect(Collectors.toMap(id -> id, id -> false));
 
         // 응답 데이터 업데이트
         updateContent(content, stockTypeIconsMap, subscriptionMap, profitRateDataMap);
@@ -88,43 +109,42 @@ public class StrategyListingService {
         return new PageResponseDto<>(content);
     }
 
-    private PageResponseDto<MyStrategySimpleResponse> updateResponsesWithoutSubscription(Long userId,
-                                                                                         Page<MyStrategySimpleResponse> content) {
-        // 전략 ID 추출
-        List<Long> strategyIds = getMyStrategyIds(content);
-
-        // 배치 쿼리를 통해 필요한 데이터 조회
-        Map<Long, List<String>> stockTypeIconsMap = strategyRepository.findStockTypeIconsMap(strategyIds);
-        Map<Long, List<Tuple>> profitRateDataMap = strategyRepository.findProfitRateDataMap(strategyIds);
-
-        // 응답 데이터 업데이트
-        updateContent(content, stockTypeIconsMap, null, profitRateDataMap);
-
-        return new PageResponseDto<>(content);
-    }
-
-
-    private List<Long> getStrategyIds(Page<StrategySimpleResponse> content) {
-        return content.getContent()
-                .stream()
-                .map(StrategySimpleResponse::getStrategyId)
-                .toList();
-    }
-
-    private List<Long> getMyStrategyIds(Page<MyStrategySimpleResponse> content) {
-        return content.getContent()
-                .stream()
-                .map(MyStrategySimpleResponse::getStrategyId)
-                .toList();
-    }
-
-    /***
-     * 응답 데이터 업데이트
-     * 각 전략 응답에 대해 종목 아이콘, 구독 여부, 수익률 그래프 데이터를 설정
+    /**
+     * 구독 여부 맵 생성
      *
-     * @param content 전략 응답 데이터
+     * @param userId      로그인한 유저 ID
+     * @param strategyIds 페이징으로 조회된 전략의 ID 목록
+     * @return 구독 여부 데이터 맵 (key : 전략id ,value : 구독여부)
+     */
+    private Map<Long, Boolean> generateSubscriptionMap(Long userId, List<Long> strategyIds) {
+
+        // 로그인 된 유저가 있으면 실제 구독여부 조회, 비로그인이면 구독여부 항상 false
+        return (userId != null)
+                ? strategyRepository.findBySubscriptionMap(userId, strategyIds)
+                : strategyIds.stream()
+                        .collect(Collectors.toMap(id -> id, id -> false));
+    }
+
+    /**
+     * 전략 ID 추출 공통 로직
+     *
+     * @param content 조회된 전략 데이터
+     * @param <T>     전략 응답 타입
+     * @return 전략 ID 리스트
+     */
+    private <T extends BaseStrategyResponse> List<Long> getStrategyIds(Page<T> content) {
+        return content.getContent()
+                .stream()
+                .map(BaseStrategyResponse::getStrategyId)
+                .toList();
+    }
+
+    /**
+     * 응답 데이터 업데이트 <br> 각 전략 응답에 대해 종목 아이콘, 구독 여부, 수익률 그래프 데이터를 설정
+     *
+     * @param content           전략 응답 데이터
      * @param stockTypeIconsMap 종목 아이콘 데이터 맵
-     * @param subscriptionMap 구독 여부 데이터 맵
+     * @param subscriptionMap   구독 여부 데이터 맵
      * @param profitRateDataMap 수익률 그래프 데이터 맵
      */
     private <T extends BaseStrategyResponse> void updateContent(Page<T> content,
@@ -144,17 +164,27 @@ public class StrategyListingService {
             }
 
             // 수익률 그래프 업데이트
-            List<Tuple> profitRateData = profitRateDataMap.getOrDefault(strategyId, List.of());
-
-            ProfitRateChartDto profitRateChartData = ProfitRateChartDto.builder()
-                    .dates(profitRateData.stream()
-                            .map(tuple -> tuple.get(dailyAnalysis.dailyDate.stringValue())).toList())
-                    .profitRates(profitRateData.stream()
-                            .map(tuple -> tuple.get(dailyAnalysis.cumulativeProfitLossRate)).toList())
-                    .build();
+            ProfitRateChartDto profitRateChartData = createProfitRateChartData(profitRateDataMap, strategyId);
 
             response.updateProfitRateChartData(profitRateChartData);
         });
+    }
+
+    private ProfitRateChartDto createProfitRateChartData(Map<Long, List<Tuple>> profitRateDataMap, Long strategyId) {
+        List<Tuple> profitRateData = profitRateDataMap.getOrDefault(strategyId, List.of());
+
+        List<String> dates = profitRateData.stream()
+                .map(tuple -> tuple.get(dailyAnalysis.dailyDate.stringValue()))
+                .toList();
+
+        List<Double> profitRates = profitRateData.stream()
+                .map(tuple -> tuple.get(dailyAnalysis.cumulativeProfitLossRate))
+                .toList();
+
+        return ProfitRateChartDto.builder()
+                .dates(dates)
+                .profitRates(profitRates)
+                .build();
     }
 
 }

--- a/src/main/java/com/investmetic/global/scheduler/DailyAnalysisScheduler.java
+++ b/src/main/java/com/investmetic/global/scheduler/DailyAnalysisScheduler.java
@@ -1,6 +1,7 @@
 package com.investmetic.global.scheduler;
 
 import com.investmetic.domain.strategy.model.entity.DailyAnalysis;
+import com.investmetic.domain.strategy.model.entity.Proceed;
 import com.investmetic.domain.strategy.repository.DailyAnalysisRepository;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
@@ -160,7 +161,7 @@ public class DailyAnalysisScheduler {
                     .roa(RoundUtil.roundToFifth(roa))
                     .coefficientOfVariation(RoundUtil.roundToFifth(coefficientOfVariation))
                     .sharpRatio(RoundUtil.roundToFifth(sharpRatio))
-                    .proceed(true)
+                    .proceed(Proceed.YES)
                     .build();
             dailyAnalysisRepository.save(dailyAnalysis);
             return;
@@ -470,7 +471,7 @@ public class DailyAnalysisScheduler {
                 .maxDrawDownInRate(RoundUtil.roundToFifth(maxDrawDownInRate))
                 .kpRatio(RoundUtil.roundToFifth(kpRatio))
                 .drawDownPeriod(drawDownPeriod)
-                .proceed(true)
+                .proceed(Proceed.YES)
                 .build();
 
         dailyAnalysisRepository.save(dailyAnalysis);

--- a/src/main/java/com/investmetic/global/util/exceldownload/ExcelColumn.java
+++ b/src/main/java/com/investmetic/global/util/exceldownload/ExcelColumn.java
@@ -1,12 +1,12 @@
-package com.investmetic.domain.strategy.exceldownload;
+package com.investmetic.global.util.exceldownload;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.TYPE)
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ExcelSheet {
-    String name();
+public @interface ExcelColumn {
+    String headerName();
 }

--- a/src/main/java/com/investmetic/global/util/exceldownload/ExcelSheet.java
+++ b/src/main/java/com/investmetic/global/util/exceldownload/ExcelSheet.java
@@ -1,12 +1,12 @@
-package com.investmetic.domain.strategy.exceldownload;
+package com.investmetic.global.util.exceldownload;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.FIELD)
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ExcelColumn {
-    String headerName();
+public @interface ExcelSheet {
+    String name();
 }

--- a/src/main/java/com/investmetic/global/util/exceldownload/ExcelSupport.java
+++ b/src/main/java/com/investmetic/global/util/exceldownload/ExcelSupport.java
@@ -1,4 +1,4 @@
-package com.investmetic.domain.strategy.exceldownload;
+package com.investmetic.global.util.exceldownload;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;

--- a/src/main/java/com/investmetic/global/util/exceldownload/ExcelUtils.java
+++ b/src/main/java/com/investmetic/global/util/exceldownload/ExcelUtils.java
@@ -1,4 +1,4 @@
-package com.investmetic.domain.strategy.exceldownload;
+package com.investmetic.global.util.exceldownload;
 
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;

--- a/src/test/java/com/investmetic/domain/strategy/service/MyDailyAnalysisServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/MyDailyAnalysisServiceTest.java
@@ -1,0 +1,131 @@
+package com.investmetic.domain.strategy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.investmetic.domain.TestEntity.TestEntityFactory;
+import com.investmetic.domain.strategy.dto.response.DailyAnalysisResponse;
+import com.investmetic.domain.strategy.model.entity.DailyAnalysis;
+import com.investmetic.domain.strategy.model.entity.Proceed;
+import com.investmetic.domain.strategy.model.entity.Strategy;
+import com.investmetic.domain.strategy.model.entity.TradeType;
+import com.investmetic.domain.strategy.repository.DailyAnalysisRepository;
+import com.investmetic.domain.user.model.entity.User;
+import com.investmetic.global.common.PageResponseDto;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MyDailyAnalysisServiceTest {
+
+    @Autowired
+    private StrategyAnalysisService strategyAnalysisService;
+
+    @Autowired
+    private DailyAnalysisRepository dailyAnalysisRepository;
+
+    private Strategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        User user = TestEntityFactory.createTestUser();
+        TradeType tradeType = TestEntityFactory.createTestTradeType();
+        strategy = TestEntityFactory.createTestStrategy(user, tradeType);
+    }
+
+    @Test
+    @DisplayName("dailyDate가 중복일 때 Proceed가 NO인지 테스트")
+    void 테스트1() {
+
+        LocalDate now = LocalDate.now();
+
+        DailyAnalysis dailyAnalysis1 = DailyAnalysis.builder()
+                .strategy(strategy)
+                .dailyDate(now)
+                .proceed(Proceed.NO)
+                .principal(1000L)
+                .build();
+
+        DailyAnalysis dailyAnalysis2 = DailyAnalysis.builder()
+                .strategy(strategy)
+                .dailyDate(now)
+                .proceed(Proceed.YES)
+                .principal(2000L)
+                .build();
+
+        dailyAnalysisRepository.save(dailyAnalysis1);
+        dailyAnalysisRepository.save(dailyAnalysis2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        PageResponseDto<DailyAnalysisResponse> result = strategyAnalysisService.getMyDailyAnalysis(
+                strategy.getStrategyId(), pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isNotEmpty();
+
+        // proceed가 NO인 일간분석의 principal 반환
+        assertThat(result.getContent())
+                .anyMatch(response -> response.getDailyDate().equals(now) && response.getPrincipal() == 1000L);
+    }
+
+
+    @Test
+    @DisplayName("dailyDate가 최신순으로 출력되는지 테스트")
+    void 테스트3() {
+        // Given: 두 개의 서로 다른 날짜 데이터를 생성
+        LocalDate date1 = LocalDate.of(2024, 11, 1); // 첫 번째 날짜
+        LocalDate date2 = LocalDate.of(2024, 11, 2); // 두 번째 날짜
+
+        DailyAnalysis dailyAnalysis1 = DailyAnalysis.builder()
+                .strategy(strategy)
+                .dailyDate(date1) // 날짜가 더 이전
+                .proceed(Proceed.NO)
+                .principal(1000L)
+                .build();
+
+        DailyAnalysis dailyAnalysis2 = DailyAnalysis.builder()
+                .strategy(strategy)
+                .dailyDate(date2) // 날짜가 더 최신
+                .proceed(Proceed.YES)
+                .principal(2000L)
+                .build();
+
+        dailyAnalysisRepository.save(dailyAnalysis1);
+        dailyAnalysisRepository.save(dailyAnalysis2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // When: 서비스 메서드 호출
+        PageResponseDto<DailyAnalysisResponse> result = strategyAnalysisService.getMyDailyAnalysis(
+                strategy.getStrategyId(), pageable);
+
+        // Then: 결과 검증
+        // 반환된 결과가 null이 아님을 확인
+        assertThat(result).isNotNull();
+
+        // 반환된 내용이 비어 있지 않음을 확인
+        assertThat(result.getContent()).isNotEmpty();
+
+        // 반환된 dailyDate 목록 추출
+        List<LocalDate> dailyDates = result.getContent().stream()
+                .map(DailyAnalysisResponse::getDailyDate) // 날짜만 추출
+                .collect(Collectors.toList());
+
+        // 날짜가 최신순으로 정렬되었는지 확인
+        assertThat(dailyDates).isSortedAccordingTo(Comparator.reverseOrder());
+
+    }
+
+
+}

--- a/src/test/java/com/investmetic/domain/strategy/service/StrategyListingServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/StrategyListingServiceTest.java
@@ -1,0 +1,110 @@
+package com.investmetic.domain.strategy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.investmetic.domain.strategy.dto.request.SearchRequest;
+import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
+import com.investmetic.domain.strategy.repository.StrategyRepository;
+import com.investmetic.global.common.PageResponseDto;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+class StrategyListingServiceTest {
+    @Mock
+    private StrategyRepository strategyRepository;
+
+    @InjectMocks
+    private StrategyListingService strategyListingService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("필터 기반 전략 목록 조회 테스트")
+    void testSearchByFilters() {
+        // Given: 필터 검색 요청과 Mock 데이터 준비
+        SearchRequest request = new SearchRequest();
+        Long userId = 1L; // 로그인한 사용자 ID
+        PageRequest pageable = PageRequest.of(0, 10); // 페이징 요청
+
+        // Mock 데이터 (전략 목록)
+        List<StrategySimpleResponse> mockContent = List.of(
+                new StrategySimpleResponse(1L, "전략 1", "user1Img",
+                        "user1", "icon1", 10L, 5.0, 15.0, 10.0, 100, 4.5, 20),
+                new StrategySimpleResponse(2L, "전략 2", "user2Img",
+                        "user2", "icon2", 20L, 6.0, 25.0, 15.0, 200, 4.0, 30)
+        );
+        Page<StrategySimpleResponse> mockPage = new PageImpl<>(mockContent);
+
+        when(strategyRepository.searchBy(request, pageable)).thenReturn(mockPage);
+        when(strategyRepository.findBySubscriptionMap(eq(userId), anyList()))
+                .thenReturn(Map.of(1L, true, 2L, false));
+        when(strategyRepository.findStockTypeIconsMap(anyList()))
+                .thenReturn(Map.of(1L, List.of("전략목록 아이콘1", "전략목록 아이콘2"), 2L, List.of("전략목록 아이콘2")));
+
+        // When
+        PageResponseDto<StrategySimpleResponse> response = strategyListingService.search(request, userId,
+                pageable);
+
+        // Then
+        assertThat(response).isNotNull(); // 응답이 null이 아님
+        assertThat(response.getContent()).hasSize(2); // 두 개의 전략 반환
+        assertThat(response.getContent().get(0).getStrategyName()).isEqualTo("전략 1"); // 첫 번째 전략 이름 확인
+        assertThat(response.getContent().get(1).getStrategyName()).isEqualTo("전략 2"); // 두 번째 전략 이름 확인
+        assertThat(response.getContent().get(0).getStockTypeIconUrls().get(0)).isEqualTo("전략목록 아이콘1");
+        assertThat(response.getContent().get(0).getStockTypeIconUrls().get(1)).isEqualTo("전략목록 아이콘2");
+        assertThat(response.getContent().get(1).getStockTypeIconUrls().get(0)).isEqualTo("전략목록 아이콘2");
+        assertThat(response.getContent().get(0).getIsSubscribed()).isTrue(); // 첫 번째 전략 구독 여부 확인
+        assertThat(response.getContent().get(1).getIsSubscribed()).isFalse(); // 두 번째 전략 구독 여부 확인
+    }
+
+
+    @Test
+    @DisplayName("구독한 전략 목록 조회 테스트")
+    void testGetSubscribedStrategies() {
+        // Given: 사용자 ID와 Mock 데이터 준비
+        Long userId = 1L;
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // Mock 데이터 (구독한 전략 목록)
+        List<StrategySimpleResponse> mockContent = List.of(
+                new StrategySimpleResponse(1L, "전략 1", "url1", "user1", "icon1", 10L, 5.0, 15.0, 10.0,
+                        100, 4.5, 20),
+                new StrategySimpleResponse(2L, "전략 2", "url2", "user2", "icon2", 20L, 6.0, 25.0, 15.0,
+                        200, 4.0, 30)
+        );
+        Page<StrategySimpleResponse> mockPage = new PageImpl<>(mockContent);
+
+        // Mock 동작 정의
+        when(strategyRepository.findSubscribedStrategies(userId, pageable)).thenReturn(mockPage);
+        when(strategyRepository.findStockTypeIconsMap(anyList())).thenReturn(
+                Map.of(1L, List.of("icon1"), 2L, List.of("icon2")));
+        when(strategyRepository.findProfitRateDataMap(anyList())).thenReturn(Map.of());
+
+        // When: 서비스 메서드 호출
+        PageResponseDto<StrategySimpleResponse> response = strategyListingService.getSubscribedStrategies(userId,
+                pageable);
+
+        // Then: 결과 검증
+        assertThat(response).isNotNull();
+        assertThat(response.getContent()).hasSize(2);
+        assertThat(response.getContent().get(0).getIsSubscribed()).isTrue(); // 구독된 상태
+        assertThat(response.getContent().get(1).getIsSubscribed()).isTrue(); // 구독된 상태
+    }
+
+
+}


### PR DESCRIPTION
## 📌 PR 개요
- 이 PR의 목적과 변경된 내용을 간략히 설명하세요. 

## #️⃣연관된 이슈

> ex) #43, #41, #36, 

## 📝작업 내용

- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 마이페이지 구독한 전략 목록 조회기능 구현
- 마이페이지 나의전략 일간 분석 조회( 트레이더 전용) 기능 구현
    -  Proceed에 따른 조회,
    -  Proceed enum타입으로 변경
- 마이페이지 나의전략 상세정보 조회기능 구현
-  전략 랭킹페이지 검색(항목+알고리즘) api 한개로 합치기
- 전략 랭킹페이지 진입시 종목,매매유형 조회 응답 리팩토링 (필요없는 응답 제거)
-  리뷰 목록 조회 응답 리팩토링 (필요없는 응답 제거)


