### PR TITLE
Feat/delete daily strategy analysis #34

### DIFF
--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -137,7 +137,7 @@ public class StrategyController {
     @DeleteMapping("{strategyId}/daily-analysis")
     @Operation(summary = "전략 (일간 분석) 삭제(전체 삭제 포함)", description = "<a href='https://field-sting-eff.notion.site/ca5091b0aaa54a39b94c6f1cd4a832af?pvs=4' target='_blank'>API 명세서(1개 삭제)</a><br/><a href='https://field-sting-eff.notion.site/5d021bd7410942e185d6e2025079041c?pvs=4' target='_blank'>API 명세서(전체 삭제)</a>")
     public ResponseEntity<BaseResponse<Void>> deleteStrategyAllDailyAnalysis(@PathVariable Long strategyId,
-                                                                             @RequestParam(required = false) Optional<String> analysisId) {
+                                                                             @RequestParam(required = false) Optional<Long> analysisId) {
         analysisId.ifPresentOrElse(
                 id -> strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, id),
                 () -> strategyAnalysisService.deleteStrategyAllDailyAnalysis(strategyId)

--- a/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
+++ b/src/main/java/com/investmetic/domain/strategy/controller/StrategyController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Pageable;
@@ -134,9 +135,14 @@ public class StrategyController {
     }
 
     @DeleteMapping("{strategyId}/daily-analysis")
-    @Operation(summary = "전략 (일간 분석) 전체(일간 데이터) 삭제", description = "<a href='https://field-sting-eff.notion.site/5d021bd7410942e185d6e2025079041c?pvs=4' target='_blank'>API 명세서</a>")
-    public ResponseEntity<BaseResponse<Void>> deleteStrategyAllDailyAnalysis(@PathVariable Long strategyId) {
-        strategyAnalysisService.deleteStrategyAllDailyAnalysis(strategyId);
+    @Operation(summary = "전략 (일간 분석) 삭제(전체 삭제 포함)", description = "<a href='https://field-sting-eff.notion.site/ca5091b0aaa54a39b94c6f1cd4a832af?pvs=4' target='_blank'>API 명세서(1개 삭제)</a><br/><a href='https://field-sting-eff.notion.site/5d021bd7410942e185d6e2025079041c?pvs=4' target='_blank'>API 명세서(전체 삭제)</a>")
+    public ResponseEntity<BaseResponse<Void>> deleteStrategyAllDailyAnalysis(@PathVariable Long strategyId,
+                                                                             @RequestParam(required = false) Optional<String> analysisId) {
+        analysisId.ifPresentOrElse(
+                id -> strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, id),
+                () -> strategyAnalysisService.deleteStrategyAllDailyAnalysis(strategyId)
+        );
+
         return BaseResponse.success(SuccessCode.DELETED);
     }
 

--- a/src/main/java/com/investmetic/domain/strategy/repository/DailyAnalysisRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/DailyAnalysisRepository.java
@@ -80,4 +80,8 @@ public interface DailyAnalysisRepository extends JpaRepository<DailyAnalysis, Lo
     boolean existsByStrategyAndDailyDate(Strategy strategy, LocalDate dailyDate);
 
     void deleteAllByStrategy(Strategy strategy);
+
+    boolean existsByStrategyAndDailyAnalysisId(Strategy strategy, Long analysisId);
+
+    void deleteByStrategyAndDailyAnalysisId(Strategy strategy, Long analysisId);
 }

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyAnalysisService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyAnalysisService.java
@@ -82,22 +82,19 @@ public class StrategyAnalysisService {
     }
 
     @Transactional
-    public void deleteStrategyDailyAnalysis(Long strategyId, String analysisId) {
+    public void deleteStrategyDailyAnalysis(Long strategyId, Long analysisId) {
         Strategy strategy = findStrategyById(strategyId);
 
         // TODO : 유저 권한 확인 로직 추가 예정
         verifyUserPermission(strategy);
 
-        // analysisId Long 변환
-        Long analysisIdAsLong = parseAnalysisId(analysisId);
-
         // 존재 여부 확인
-        boolean exists = dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong);
+        boolean exists = dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisId);
         if (!exists) {
             throw new BusinessException(ErrorCode.INVALID_TYPE_VALUE);
         }
 
-        dailyAnalysisRepository.deleteByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong);
+        dailyAnalysisRepository.deleteByStrategyAndDailyAnalysisId(strategy, analysisId);
     }
 
     private Strategy findStrategyById(Long strategyId) {
@@ -109,14 +106,6 @@ public class StrategyAnalysisService {
     public PageResponseDto<DailyAnalysisResponse> getMyDailyAnalysis(Long strategyId, Pageable pageable) {
         Page<DailyAnalysisResponse> myDailyAnalysis = dailyAnalysisRepository.findMyDailyAnalysis(strategyId, pageable);
         return new PageResponseDto<>(myDailyAnalysis);
-    }
-
-    private Long parseAnalysisId(String analysisId) {
-        try {
-            return Long.parseLong(analysisId);
-        } catch (NumberFormatException e) {
-            throw new BusinessException(ErrorCode.INVALID_TYPE_VALUE);
-        }
     }
 
     private void verifyUserPermission(Strategy strategy) {

--- a/src/test/java/com/investmetic/domain/strategy/service/StrategyDailyAnalysisServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/StrategyDailyAnalysisServiceTest.java
@@ -77,14 +77,14 @@ class StrategyDailyAnalysisServiceTest {
     void 테스트_1() {
         Long strategyId = 1L;
         LocalDate date = LocalDate.now();
-        TraderDailyAnalysisRequestDto requestDto = TraderDailyAnalysisRequestDto.builder()
+        TraderDailyAnalysisRequestDto traderDailyAnalysisRequestDto = TraderDailyAnalysisRequestDto.builder()
                 .date(date)
                 .transaction(100L)
                 .dailyProfitLoss(100L)
                 .build();
 
         when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
-        strategyAnalysisService.createDailyAnalysis(strategyId, List.of(requestDto));
+        strategyAnalysisService.createDailyAnalysis(strategyId, List.of(traderDailyAnalysisRequestDto));
 
         verify(dailyAnalysisRepository, times(1)).save(any(DailyAnalysis.class));
     }
@@ -94,7 +94,7 @@ class StrategyDailyAnalysisServiceTest {
     void 테스트_2() {
         Long strategyId = 1L;
         LocalDate date = LocalDate.now();
-        TraderDailyAnalysisRequestDto requestDto = TraderDailyAnalysisRequestDto.builder()
+        TraderDailyAnalysisRequestDto traderDailyAnalysisRequestDto = TraderDailyAnalysisRequestDto.builder()
                 .date(date)
                 .transaction(100L)
                 .dailyProfitLoss(200L)
@@ -102,7 +102,7 @@ class StrategyDailyAnalysisServiceTest {
 
         when(strategyRepository.findById(strategyId)).thenReturn(Optional.empty());
 
-        List<TraderDailyAnalysisRequestDto> requestList = List.of(requestDto);
+        List<TraderDailyAnalysisRequestDto> requestList = List.of(traderDailyAnalysisRequestDto);
 
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> strategyAnalysisService.createDailyAnalysis(strategyId, requestList));
@@ -204,5 +204,60 @@ class StrategyDailyAnalysisServiceTest {
         assertEquals(ErrorCode.DAILY_ANALYSIS_NOT_FOUND, exception.getErrorCode());
         verify(strategyRepository).findById(1L);
         verify(dailyAnalysisRepository).findDailyAnalysisByStrategyAndDate(strategy, LocalDate.now());
+    }
+
+
+    @Test
+    @DisplayName("전략 일간 분석 삭제 - 성공 테스트")
+    void 테스트_9() {
+        Long strategyId = 1L;
+        String analysisId = "123";
+        Long analysisIdAsLong = Long.parseLong(analysisId);
+
+        when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
+        when(dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong))
+                .thenReturn(true);
+
+        strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, analysisId);
+
+        verify(dailyAnalysisRepository, times(1))
+                .deleteByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong);
+    }
+
+    @Test
+    @DisplayName("전략 일간 분석 삭제 - 해당 일간 분석이 존재하지 않을 경우 예외 발생")
+    void 테스트_10() {
+        Long strategyId = 1L;
+        String analysisId = "123";
+        Long analysisIdAsLong = Long.parseLong(analysisId);
+
+        when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
+        when(dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong))
+                .thenReturn(false);
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, analysisId)
+        );
+
+        assertEquals(ErrorCode.INVALID_TYPE_VALUE, exception.getErrorCode());
+        verify(dailyAnalysisRepository, never())
+                .deleteByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong);
+    }
+
+    @Test
+    @DisplayName("전략 일간 분석 삭제 - 전략 분석 아이디가 숫자가 아닐 경우 예외 발생")
+    void 테스트_11() {
+        Long strategyId = 1L;
+        String invalidAnalysisId = "abc"; // 숫자가 아닌 값
+
+        when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
+
+        BusinessException exception = assertThrows(BusinessException.class, () ->
+                strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, invalidAnalysisId)
+        );
+
+        assertEquals(ErrorCode.INVALID_TYPE_VALUE, exception.getErrorCode());
+        verify(dailyAnalysisRepository, never())
+                .deleteByStrategyAndDailyAnalysisId(any(), any());
     }
 }

--- a/src/test/java/com/investmetic/domain/strategy/service/StrategyDailyAnalysisServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/StrategyDailyAnalysisServiceTest.java
@@ -211,28 +211,26 @@ class StrategyDailyAnalysisServiceTest {
     @DisplayName("전략 일간 분석 삭제 - 성공 테스트")
     void 테스트_9() {
         Long strategyId = 1L;
-        String analysisId = "123";
-        Long analysisIdAsLong = Long.parseLong(analysisId);
+        Long analysisId = 123L;
 
         when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
-        when(dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong))
+        when(dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisId))
                 .thenReturn(true);
 
         strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, analysisId);
 
         verify(dailyAnalysisRepository, times(1))
-                .deleteByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong);
+                .deleteByStrategyAndDailyAnalysisId(strategy, analysisId);
     }
 
     @Test
     @DisplayName("전략 일간 분석 삭제 - 해당 일간 분석이 존재하지 않을 경우 예외 발생")
     void 테스트_10() {
         Long strategyId = 1L;
-        String analysisId = "123";
-        Long analysisIdAsLong = Long.parseLong(analysisId);
+        Long analysisId = 123L;
 
         when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
-        when(dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong))
+        when(dailyAnalysisRepository.existsByStrategyAndDailyAnalysisId(strategy, analysisId))
                 .thenReturn(false);
 
         BusinessException exception = assertThrows(BusinessException.class, () ->
@@ -241,23 +239,6 @@ class StrategyDailyAnalysisServiceTest {
 
         assertEquals(ErrorCode.INVALID_TYPE_VALUE, exception.getErrorCode());
         verify(dailyAnalysisRepository, never())
-                .deleteByStrategyAndDailyAnalysisId(strategy, analysisIdAsLong);
-    }
-
-    @Test
-    @DisplayName("전략 일간 분석 삭제 - 전략 분석 아이디가 숫자가 아닐 경우 예외 발생")
-    void 테스트_11() {
-        Long strategyId = 1L;
-        String invalidAnalysisId = "abc"; // 숫자가 아닌 값
-
-        when(strategyRepository.findById(strategyId)).thenReturn(Optional.of(strategy));
-
-        BusinessException exception = assertThrows(BusinessException.class, () ->
-                strategyAnalysisService.deleteStrategyDailyAnalysis(strategyId, invalidAnalysisId)
-        );
-
-        assertEquals(ErrorCode.INVALID_TYPE_VALUE, exception.getErrorCode());
-        verify(dailyAnalysisRepository, never())
-                .deleteByStrategyAndDailyAnalysisId(any(), any());
+                .deleteByStrategyAndDailyAnalysisId(strategy, analysisId);
     }
 }


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 전략 일간 분석 삭제 기능 구현

> ## #️⃣연관된 이슈

> #34 

## 💡 리뷰어에게 하고 싶은 말

- 전략 일간 분석 전체 삭제 메서드에 추가했습니다.
- 일간 분석 id가 파라미터에 담아 요청하면 해당 id값 일간 분석 삭제.
- 파라미터에 값이 없으면 전체 삭제
-  @5jeong 일간 분석 id로 삭제하기 때문에 [일간 분석 조회](https://field-sting-eff.notion.site/445709f04679440cbd729c6cabf64f0c?pvs=4)에 일간 분석 id 값도 추가가 필요해보입니다. (회의 예정)
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
