### PR TITLE
Bug/email auth #130

### DIFF
--- a/src/main/java/com/investmetic/domain/user/controller/EmailAuthController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/EmailAuthController.java
@@ -48,6 +48,20 @@ public class EmailAuthController {
 
     }
 
+
+    @Operation(summary = "회원가입시 이메일 인증 코드 전송",
+            description = "<a href='https://www.notion.so/a6dff91d8c204ec2806a9478ff258b33' target='_blank'>API 명세서</a>")
+    @GetMapping("/signup")
+    public ResponseEntity<BaseResponse<Void>> sendSignUpCode(
+            @RequestParam String email) {
+
+        // 코드 생성 및 발송.
+        userService.sendSignUpCode(email); //코드 redis 저장 있어야함.
+
+        return BaseResponse.success(SuccessCode.OK);
+    }
+
+
     // 회원가입시 인증코드 검증
     @Operation(summary = "회원가입시 이메일 인증 코드 검증",
             description = "<a href='https://www.notion.so/1b6156c899da4dbd97c1638faa392128' target='_blank'>API 명세서</a>")

--- a/src/main/java/com/investmetic/domain/user/controller/LoginController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/LoginController.java
@@ -1,0 +1,25 @@
+package com.investmetic.domain.user.controller;
+
+
+import com.investmetic.domain.user.dto.request.PasswordDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "로그인 API")
+@RestController
+@RequestMapping("/login")
+public class LoginController {
+
+    @Operation(summary = "로그인 기능",
+            description = "<a href='https://www.notion.so/789758335eef4feb879460367a16cf90' target='_blank'>API 명세서</a>")
+    @PostMapping
+    public void login(@RequestBody PasswordDto passwordDto){
+
+        // 여기까지 안들어옴 그전에 필터에서 반환. 보여주기용.
+    }
+
+}

--- a/src/main/java/com/investmetic/domain/user/dto/request/UserModifyDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/request/UserModifyDto.java
@@ -30,21 +30,17 @@ public class UserModifyDto {
     //디자인을 보면 email은 변경하지 못하게 한다. 토큰의 email과 dto의 email이 일치하는지 검증.
     private String email;
 
-    //Null일 경우 변경 안함.
-    private Boolean infoAgreement;
-
     @NotNull
     private Boolean imageChange;
 
     @Builder
     public UserModifyDto(String nickname, String password, ImageMetadata imageDto, String phone, String email,
-                         Boolean infoAgreement, Boolean imageChange) {
+                         Boolean imageChange) {
         this.nickname = nickname;
         this.password = password;
         this.imageDto = imageDto;
         this.phone = phone;
         this.email = email;
-        this.infoAgreement = infoAgreement;
         this.imageChange = imageChange;
     }
 

--- a/src/main/java/com/investmetic/domain/user/model/entity/User.java
+++ b/src/main/java/com/investmetic/domain/user/model/entity/User.java
@@ -109,10 +109,6 @@ public class User extends BaseEntity {
             this.nickname = userModifyDto.getNickname();
         }
 
-        if (userModifyDto.getInfoAgreement() != null) {
-            this.infoAgreement = userModifyDto.getInfoAgreement();
-        }
-
         // 기본 이미지를 이용하거나 새로운 사진을 업로드하는 경우. null 또는 presignedUrl
         if (Boolean.TRUE.equals(userModifyDto.getImageChange())) {
             this.imageUrl = imageUrl;

--- a/src/main/java/com/investmetic/domain/user/service/UserAdminService.java
+++ b/src/main/java/com/investmetic/domain/user/service/UserAdminService.java
@@ -7,11 +7,11 @@ import com.investmetic.domain.user.model.ActionType;
 import com.investmetic.domain.user.model.Role;
 import com.investmetic.domain.user.model.entity.User;
 import com.investmetic.domain.user.model.entity.UserHistory;
-import com.investmetic.domain.user.repository.UserHistoryRepository;
 import com.investmetic.domain.user.repository.UserRepository;
 import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
+import com.investmetic.global.util.stibee.StibeeEmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserAdminService {
 
     private final UserRepository userRepository;
-    private final UserHistoryRepository userHistoryRepository;
+    private final StibeeEmailService stibeeEmailService;
 
 
     /**
@@ -115,6 +115,7 @@ public class UserAdminService {
 
                 // 회원 변경 이력 저장.
                 user.addUserHistory(UserHistory.createEntity(user, ActionType.DEMOTION));
+                stibeeEmailService.releaseGroup(user.getEmail());
             }
 
             // 2. TRADER로 받는경우 해당 회원이 TRADER_ADMIN이 아니면 Exception 발생.
@@ -124,6 +125,7 @@ public class UserAdminService {
                 }
                 user.changeRole(Role.TRADER);
                 user.addUserHistory(UserHistory.createEntity(user, ActionType.DEMOTION));
+                stibeeEmailService.releaseGroup(user.getEmail());
             }
 
             // 3. ADMIN으로 받는경우 TRADER면 TRADER_ADMIN, INVESTOR면 INVESTOR_ADMIN으로
@@ -139,6 +141,7 @@ public class UserAdminService {
                     throw new BusinessException(ErrorCode.INVALID_TYPE_VALUE);
                 }
                 user.addUserHistory(UserHistory.createEntity(user, ActionType.PROMOTION));
+                stibeeEmailService.assignGroup(user.getEmail());
             }
 
             // 그 외의 값은 모두 예외처리.

--- a/src/main/java/com/investmetic/domain/user/service/UserService.java
+++ b/src/main/java/com/investmetic/domain/user/service/UserService.java
@@ -83,6 +83,32 @@ public class UserService {
         redisUtil.setDataExpire(email, code, 60 * 30L);
     }
 
+    //TODO : Thread.sleep 리팩토링 시급.
+    // 비로그인 유저에게 인증코드를 발송하기위한 메서드.
+    public void sendSignUpCode(String email) {
+        // 인증 코드 생성.
+        String code = createdCode();
+
+        // 해당 이메일로 인증코드 발송.
+        if(!emailService.sendSignUpCode(email, code)){
+
+            //비로그인 회원이 임시 주소록에 추가되지 않은경우.
+            throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
+        }
+        try{
+            Thread.sleep(2100);
+        }catch (InterruptedException e){
+            e.printStackTrace();
+        }
+
+        // 임시 주소록에서 해당 회원 삭제.
+        emailService.deleteTemporalSubscriber(email);
+
+        // code를 redis에 저장(30 minute)
+        redisUtil.setDataExpire(email, code, 60 * 30L);
+    }
+
+
     public AvaliableDto checkNicknameDuplicate(String nickname) {
 
         boolean isDuplicate = userRepository.existsByNickname(nickname);

--- a/src/main/java/com/investmetic/global/util/stibee/StibeeEmailService.java
+++ b/src/main/java/com/investmetic/global/util/stibee/StibeeEmailService.java
@@ -49,7 +49,7 @@ public class StibeeEmailService {
     private String traderGroup;
 
 
-
+    // 임시 주소록에서 회원 추가 후에 코드 전송.
     public boolean sendSignUpCode(String email, String code){
 
         // 정보 없이 이메일만 발송 가능하도록 회원 세팅.
@@ -63,7 +63,7 @@ public class StibeeEmailService {
         // 주소록에 회원 추가.
         StibeeSubscribeResponse<SignUpValue> signUpResponse= stibeeClient.subscribe(temporalAdressBook, emailSubscribe);
 
-        log.info("signUpResponse {}",signUpResponse);
+//        log.info("signUpResponse {}",signUpResponse);
 
         // 임시 주소록에 회원 등록
         if(!signUpResponse.isOk()){
@@ -82,11 +82,12 @@ public class StibeeEmailService {
         }
     }
 
+    // 임시 주소록에서 회원 삭제시
     public void deleteTemporalSubscriber(String email){
 
         StibeeSubscribeResponse<DeleteValue> deleteResponse = stibeeClient.deleteSubscriber(temporalAdressBook, List.of(email));
 
-        log.info("deleteResponse {}",deleteResponse);
+//        log.info("deleteResponse {}",deleteResponse);
 
         // 미삭제시 회원 수동 삭제할 수 있도록.
         if(!deleteResponse.isOk()){

--- a/src/main/java/com/investmetic/global/util/stibee/StibeeEmailService.java
+++ b/src/main/java/com/investmetic/global/util/stibee/StibeeEmailService.java
@@ -4,19 +4,26 @@ package com.investmetic.global.util.stibee;
 import com.investmetic.domain.user.dto.request.UserModifyDto;
 import com.investmetic.domain.user.model.Role;
 import com.investmetic.domain.user.model.entity.User;
+import com.investmetic.global.exception.BusinessException;
+import com.investmetic.global.exception.ErrorCode;
 import com.investmetic.global.util.stibee.client.AutoApiStibeeClient;
 import com.investmetic.global.util.stibee.client.StibeeClient;
+import com.investmetic.global.util.stibee.dto.object.DeleteValue;
 import com.investmetic.global.util.stibee.dto.object.EmailAndCode;
+import com.investmetic.global.util.stibee.dto.object.SignUpValue;
 import com.investmetic.global.util.stibee.dto.request.SubscriberField;
 import com.investmetic.global.util.stibee.dto.request.EmailSubscribe;
+import com.investmetic.global.util.stibee.dto.response.StibeeSubscribeResponse;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StibeeEmailService {
 
     // HttpInterface로 사용.
@@ -29,6 +36,9 @@ public class StibeeEmailService {
     @Value("${stibee.email.address-book.default.address}")
     private int defaultAddressBook;
 
+    @Value("${stibee.email.address-book.temporal.address}")
+    private int temporalAdressBook;
+
     @Value("${stibee.email.address-book.default.group.admin}")
     private String adminGroup;
 
@@ -40,31 +50,75 @@ public class StibeeEmailService {
 
 
 
+    public boolean sendSignUpCode(String email, String code){
+
+        // 정보 없이 이메일만 발송 가능하도록 회원 세팅.
+        SubscriberField subscriber = SubscriberField.create(email, null);
+
+        EmailSubscribe emailSubscribe = EmailSubscribe.toSubscriber(null, subscriber);
+
+        // 이메일, 인증번호 세팅
+        EmailAndCode emailAndCode = new EmailAndCode(email, code);
+
+        // 주소록에 회원 추가.
+        StibeeSubscribeResponse<SignUpValue> signUpResponse= stibeeClient.subscribe(temporalAdressBook, emailSubscribe);
+
+        log.info("signUpResponse {}",signUpResponse);
+
+        // 임시 주소록에 회원 등록
+        if(!signUpResponse.isOk()){
+
+            //등록 안되면 false반환.
+            return false;
+        }
+
+        String response = autoApiStibeeClient.sendSignUpCode(emailAndCode);
+
+        if (!"ok".equals(response)) {
+            log.error("인증코드 발송 실패: {}, {}", response, email);
+            throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
+        }else{
+            return true;
+        }
+    }
+
+    public void deleteTemporalSubscriber(String email){
+
+        StibeeSubscribeResponse<DeleteValue> deleteResponse = stibeeClient.deleteSubscriber(temporalAdressBook, List.of(email));
+
+        log.info("deleteResponse {}",deleteResponse);
+
+        // 미삭제시 회원 수동 삭제할 수 있도록.
+        if(!deleteResponse.isOk()){
+            log.error("email not deleted {}", email);
+        }
+    }
+
+
+
     /**
      * 주소록에 추가 - 회원 가입시, 탈퇴한 회원이 똑같은 이메일로 다시 회원가입 한 경우 이메일 발송 안함. SuperAdmin은 회원가입, 등급 변경 해도 안됨.
      *
      * @param user 주소록에 필요한 사용자 정보 필드가 추가될 수 있으므로 UserEntity를 받습니다.
      */
-    public Boolean addSubscriber(User user) {
+    public void addSubscriber(User user) {
 
         List<String> groupIds = new ArrayList<>();
 
         // 트레이더인지 투자자인지 그룹으로 구분.
         groupIds.add(Role.isTrader(user.getRole()) ? traderGroup : investGroup);
 
-        //이메일 수신 동의 -> 광고성 정보 수신 동의
-        String adAgreed = Boolean.TRUE.equals(user.getInfoAgreement()) ? "Y" : "N";
-
         // 해당 회원 약관 동의 날짜 업데이트
-        SubscriberField subscriber = SubscriberField.create(user.getEmail(), user.getUserName(), adAgreed);
+        SubscriberField subscriber = SubscriberField.create(user.getEmail(), user.getUserName());
         subscriber.updateTermDate();
 
         EmailSubscribe emailSubscribe = EmailSubscribe.toSubscriber(groupIds, subscriber);
 
         // 실패 이유는 SignupValue에서 찾을 수 있음.
         // 실제 이메일 발송되는 주소록에 저장.
-        return stibeeClient.subscribe(defaultAddressBook, emailSubscribe).isOk();
+        stibeeClient.subscribe(defaultAddressBook, emailSubscribe);
     }
+
 
     /**
      * 이미등록된 회원의 정보를 변경.
@@ -81,10 +135,8 @@ public class StibeeEmailService {
             groupIds.add(adminGroup);
         }
 
-        String adAgreed = Boolean.TRUE.equals(user.getInfoAgreement()) ? "Y" : "N";
-
         // 정보 변경시에는 약관 날짜 업데이트하지 않기.
-        SubscriberField subscriber = SubscriberField.create(user.getEmail(), null, adAgreed);
+        SubscriberField subscriber = SubscriberField.create(user.getEmail(), null);
 
         EmailSubscribe emailSubscribe = EmailSubscribe.toManual(groupIds, subscriber);
 
@@ -97,7 +149,7 @@ public class StibeeEmailService {
      */
     public Boolean updateSubscriberTermDate(String email) {
 
-        SubscriberField subscriber = SubscriberField.create(email, null, null);
+        SubscriberField subscriber = SubscriberField.create(email, null);
         //약관날짜 업데이트
         subscriber.updateTermDate();
 

--- a/src/main/java/com/investmetic/global/util/stibee/StibeeEmailService.java
+++ b/src/main/java/com/investmetic/global/util/stibee/StibeeEmailService.java
@@ -37,7 +37,7 @@ public class StibeeEmailService {
     private int defaultAddressBook;
 
     @Value("${stibee.email.address-book.temporal.address}")
-    private int temporalAdressBook;
+    private int temporalAddressBook;
 
     @Value("${stibee.email.address-book.default.group.admin}")
     private String adminGroup;
@@ -50,7 +50,7 @@ public class StibeeEmailService {
 
 
     // 임시 주소록에서 회원 추가 후에 코드 전송.
-    public boolean sendSignUpCode(String email, String code){
+    public boolean sendSignUpCode(String email, String code) {
 
         // 정보 없이 이메일만 발송 가능하도록 회원 세팅.
         SubscriberField subscriber = SubscriberField.create(email, null);
@@ -61,12 +61,13 @@ public class StibeeEmailService {
         EmailAndCode emailAndCode = new EmailAndCode(email, code);
 
         // 주소록에 회원 추가.
-        StibeeSubscribeResponse<SignUpValue> signUpResponse= stibeeClient.subscribe(temporalAdressBook, emailSubscribe);
+        StibeeSubscribeResponse<SignUpValue> signUpResponse
+                = stibeeClient.subscribe(temporalAddressBook, emailSubscribe);
 
 //        log.info("signUpResponse {}",signUpResponse);
 
         // 임시 주소록에 회원 등록
-        if(!signUpResponse.isOk()){
+        if (!signUpResponse.isOk()) {
 
             //등록 안되면 false반환.
             return false;
@@ -77,15 +78,16 @@ public class StibeeEmailService {
         if (!"ok".equals(response)) {
             log.error("인증코드 발송 실패: {}, {}", response, email);
             throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
-        }else{
-            return true;
         }
+
+        return true;
     }
 
     // 임시 주소록에서 회원 삭제시
     public void deleteTemporalSubscriber(String email){
 
-        StibeeSubscribeResponse<DeleteValue> deleteResponse = stibeeClient.deleteSubscriber(temporalAdressBook, List.of(email));
+        StibeeSubscribeResponse<DeleteValue> deleteResponse
+                = stibeeClient.deleteSubscriber(temporalAddressBook, List.of(email));
 
 //        log.info("deleteResponse {}",deleteResponse);
 

--- a/src/main/java/com/investmetic/global/util/stibee/client/AutoApiStibeeClient.java
+++ b/src/main/java/com/investmetic/global/util/stibee/client/AutoApiStibeeClient.java
@@ -15,4 +15,10 @@ public interface AutoApiStibeeClient {
     void sendAuthenticationCode(@RequestBody EmailAndCode emailAndCode);
 
 
+    @PostExchange("/NWMwN2QyMjUtOGUyNy00ZGRkLWJiZjItNWFhYTMzMmFlYTI5")
+    String sendSignUpCode(@RequestBody EmailAndCode emailAndCode);
+
+
+
+
 }

--- a/src/main/java/com/investmetic/global/util/stibee/dto/request/SubscriberField.java
+++ b/src/main/java/com/investmetic/global/util/stibee/dto/request/SubscriberField.java
@@ -18,18 +18,17 @@ public class SubscriberField {
     private LocalDateTime termDate; // 약관 동의일
 
     @JsonProperty("$ad_agreed")
-    private final String adAgreed;
+    private final String adAgreed ="Y";
 
 
-    private SubscriberField(String email, String name, String adAgreed) {
+    private SubscriberField(String email, String name) {
         this.email = email;
         this.name = name;
-        this.adAgreed = adAgreed;
     }
 
-    public static SubscriberField create(String email, String name, String adAgreed){
+    public static SubscriberField create(String email, String name){
 
-        return new SubscriberField(email, name, adAgreed);
+        return new SubscriberField(email, name);
     }
 
     //약관 날짜 설정.

--- a/src/test/java/com/investmetic/domain/user/controller/UserMyPageControllerTest.java
+++ b/src/test/java/com/investmetic/domain/user/controller/UserMyPageControllerTest.java
@@ -139,7 +139,7 @@ class UserMyPageControllerTest {
             oneUserImageUpload();
 
             UserModifyDto userModifyDto = UserModifyDto.builder().email("jlwoo092513@gmail.com").nickname("테스트")
-                    .infoAgreement(Boolean.TRUE).password("asdf").phone("01012345678").imageChange(Boolean.FALSE)
+                    .password("asdf").phone("01012345678").imageChange(Boolean.FALSE)
                     .build();
 
             ResultActions resultActions = mockMvc.perform(
@@ -155,7 +155,7 @@ class UserMyPageControllerTest {
 
             // imageChange null로 보냄
             UserModifyDto userModifyDto = UserModifyDto.builder().email("jlwoo092513@gmail.com").nickname("테스트")
-                    .infoAgreement(Boolean.TRUE).password("asdf").phone("01012345678").build();
+                    .password("asdf").phone("01012345678").build();
 
             //Valid Test throw MethodArgumentNotValidException
             ResultActions resultActions = mockMvc.perform(
@@ -174,7 +174,7 @@ class UserMyPageControllerTest {
             // imageDto Valid Test
             UserModifyDto userModifyDto = UserModifyDto.builder().email("jlwoo092513@gmail.com")
                     .imageDto(new ImageMetadata("asdf.jpg", 1024 * 1024 * 5)).nickname("테스트")
-                    .infoAgreement(Boolean.TRUE).password("asdf").phone("01012345678")
+                    .password("asdf").phone("01012345678")
                     .imageChange(true) // primitive 타입으로
                     .build();
 

--- a/src/test/java/com/investmetic/domain/user/repository/UserMyPageRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/UserMyPageRepositoryTest.java
@@ -108,7 +108,7 @@ class UserMyPageRepositoryTest {
 
                     Arguments.arguments("정보 수신 동의 변경",
                             UserModifyDto.builder().email("jlwoo092513@gmail.com").imageChange(Boolean.FALSE)
-                                    .infoAgreement(Boolean.FALSE).build()),
+                                    .build()),
 
                     Arguments.arguments("비밀 번호 변경",
                             UserModifyDto.builder().email("jlwoo092513@gmail.com").imageChange(Boolean.FALSE)
@@ -132,7 +132,7 @@ class UserMyPageRepositoryTest {
             //생성한 유저 email로 DB를 찾아서 있는지 확인
             assertThat(existUser).isPresent();
 
-            UserModifyDto userModifyDto = UserModifyDto.builder().nickname("테스트").infoAgreement(Boolean.TRUE)
+            UserModifyDto userModifyDto = UserModifyDto.builder().nickname("테스트")
                     .password("dirtyCheck!!").phone("01099999999")
                     .imageDto(new ImageMetadata("TestImage.jpa", 5000)).imageChange(Boolean.TRUE).build();
 

--- a/src/test/java/com/investmetic/domain/user/service/AdminPageUserServiceTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/AdminPageUserServiceTest.java
@@ -17,6 +17,7 @@ import com.investmetic.domain.user.model.entity.User;
 import com.investmetic.domain.user.repository.UserRepository;
 import com.investmetic.global.exception.BusinessException;
 import com.investmetic.global.exception.ErrorCode;
+import com.investmetic.global.util.stibee.StibeeEmailService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -46,6 +47,9 @@ public class AdminPageUserServiceTest {
 
     @InjectMocks
     private UserAdminService userAdminService;
+
+    @Mock
+    private StibeeEmailService stibeeEmailService;
 
 
     @Nested
@@ -180,6 +184,11 @@ public class AdminPageUserServiceTest {
             //given
             User user = createOneUser(previousRole);
             when(userRepository.findById(anyLong())).thenReturn(Optional.ofNullable(user));
+            if (roleCondition == RoleCondition.ADMIN) {
+                when(stibeeEmailService.assignGroup(anyString())).thenReturn(true);
+            }else{
+                when(stibeeEmailService.releaseGroup(anyString())).thenReturn(true);
+            }
 
             // when, then 유저가 있다고 가정하고 userId는 값을 넣어줌.
             assertThatCode(() -> userAdminService.modifyRole(1L, roleCondition)).doesNotThrowAnyException();

--- a/src/test/java/com/investmetic/domain/user/service/UserInfoModifyServiceTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/UserInfoModifyServiceTest.java
@@ -62,7 +62,7 @@ class UserInfoModifyServiceTest {
 
                 Arguments.arguments("정보 수신 동의 변경",
                         UserModifyDto.builder().email("jlwoo092513@gmail.com").imageChange(Boolean.FALSE)
-                                .infoAgreement(Boolean.FALSE).build()),
+                                .build()),
 
                 Arguments.arguments("비밀 번호 변경",
                         UserModifyDto.builder().email("jlwoo092513@gmail.com").imageChange(Boolean.FALSE)
@@ -90,7 +90,7 @@ class UserInfoModifyServiceTest {
 
         // 변경된 회원값
         UserModifyDto userModifyDto = UserModifyDto.builder().email(oneUser.getEmail()).imageDto(imageMetadata)
-                .infoAgreement(Boolean.FALSE).nickname("자자ㅏㅈ").phone("01012345678").password("9999")
+                .nickname("자자ㅏㅈ").phone("01012345678").password("9999")
                 .imageChange(Boolean.TRUE).build();
 
         when(userRepository.findByEmail(userModifyDto.getEmail())).thenReturn(Optional.of(oneUser));


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 추가하려는 기능에 대해 간결하게 설명해주세요

> ## #️⃣연관된 이슈

> #130

## 💡 리뷰어에게 하고 싶은 말

-  // 임시 주소록에서 해당 회원 삭제.
        taskScheduler.schedule(() -> emailService.deleteTemporalSubscriber(email),
                Instant.now().plusSeconds(8));

클라이언트에게 먼저 완료 요청을 준 후에 회원 삭제를 8초후에 실행 시키도록 설정합니다.


- User의 등급변경시 주소록에서 그룹 할당 취소를 적용하였습니다.

- 프론트측의 요청으로 광고성 이메일 수신 동의 여부는 무조건 true로 해두었습니다.

- postman을 통해 비로그인 유저에대해
 회원가입 이메일 인증코드 요청 -> 회원가입 이메일 인증코드 검증 -> 회원가입
순서대로 인증코드 확인을 마쳤습니다. 확인 부탁드립니다.

- LoginController 추가.
Security에서 Filter로 해당 URI요청이 후킹되므로 어짜피 컨트롤러까지 요청이 도달하지 않습니다. 
프론트 분들의 요청으로 Swagger 추가 하였습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
