### PR TITLE
Bug/trader list #140

### DIFF
--- a/src/main/java/com/investmetic/domain/user/controller/UserController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.investmetic.domain.user.dto.response.TraderProfileDto;
 import com.investmetic.domain.user.service.UserService;
 import com.investmetic.global.common.PageResponseDto;
 import com.investmetic.global.exception.BaseResponse;
+import com.investmetic.global.exception.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +34,10 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<String>> signup(@RequestBody UserSignUpDto userSignUpDto) {
 
+        userService.signUp(userSignUpDto);
+
         // 이미지 저장시 presignedUrl 반환.
-        return BaseResponse.success(userService.signUp(userSignUpDto));
+        return BaseResponse.success(SuccessCode.CREATED);
     }
 
     //닉네임 중복 검사

--- a/src/main/java/com/investmetic/domain/user/controller/UserController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.investmetic.global.exception.BaseResponse;
 import com.investmetic.global.exception.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -32,7 +33,7 @@ public class UserController {
     @Operation(summary = "회원 가입",
             description = "<a href='https://www.notion.so/3b51884e19b2420e8800a18ee92c310c' target='_blank'>API 명세서</a>")
     @PostMapping("/signup")
-    public ResponseEntity<BaseResponse<String>> signup(@RequestBody UserSignUpDto userSignUpDto) {
+    public ResponseEntity<BaseResponse<String>> signup(@Valid @RequestBody UserSignUpDto userSignUpDto) {
 
         userService.signUp(userSignUpDto);
 

--- a/src/main/java/com/investmetic/domain/user/dto/request/UserSignUpDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/request/UserSignUpDto.java
@@ -3,6 +3,8 @@ package com.investmetic.domain.user.dto.request;
 import com.investmetic.domain.user.model.Role;
 import com.investmetic.domain.user.model.UserState;
 import com.investmetic.domain.user.model.entity.User;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,14 +13,32 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @Getter
 @Builder
 public class UserSignUpDto {
+    @NotNull
     private String username;
+
+    @NotNull
     private String nickname;
+
+    @NotNull
+    @Pattern(regexp = "^010-(\\d{3}|\\d{4})-(\\d{4})$")
     private String phone;
+
+    @NotNull
+    @Pattern(regexp = "^(19|20)\\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$")
     private String birthdate;
+
+    @NotNull
     private String password;
+
+    @NotNull
     private String email;
+
     private Role role;
+
+    @NotNull
     private String code;
+
+    @NotNull
     private Boolean infoAgreement; //정보제공 동의
 
     public static User toEntity(UserSignUpDto userSignUpDto, BCryptPasswordEncoder passwordEncoder) {

--- a/src/main/java/com/investmetic/domain/user/dto/request/UserSignUpDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/request/UserSignUpDto.java
@@ -1,6 +1,5 @@
 package com.investmetic.domain.user.dto.request;
 
-import com.investmetic.domain.user.dto.object.ImageMetadata;
 import com.investmetic.domain.user.model.Role;
 import com.investmetic.domain.user.model.UserState;
 import com.investmetic.domain.user.model.entity.User;
@@ -21,10 +20,8 @@ public class UserSignUpDto {
     private Role role;
     private String code;
     private Boolean infoAgreement; //정보제공 동의
-    private ImageMetadata imageMetadata;
 
-    public static User toEntity(UserSignUpDto userSignUpDto, String presignedUrl,
-                                BCryptPasswordEncoder passwordEncoder) {
+    public static User toEntity(UserSignUpDto userSignUpDto, BCryptPasswordEncoder passwordEncoder) {
         return User.builder()
                 .userName(userSignUpDto.getUsername())
                 .nickname(userSignUpDto.getNickname())
@@ -37,7 +34,6 @@ public class UserSignUpDto {
                         && userSignUpDto.getInfoAgreement()) // null 검사를 포함한 정보 제공 동의 설정
                 .joinDate(LocalDate.now())
                 .userState(UserState.ACTIVE) // 기본 사용자 상태 설정
-                .imageUrl(presignedUrl)
                 .build();
     }
 }

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustomImpl.java
@@ -132,14 +132,15 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         user.role.in(Role.TRADER, Role.TRADER_ADMIN))
                 .groupBy(user.userId)
                 .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0])) // 구독순, 전략순
-                .offset(pageable.getPageNumber())
+                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(user.count())
                 .from(user)
-                .where(user.role.in(Role.TRADER, Role.TRADER_ADMIN));
+                .where(keywordCondition(ColumnCondition.NICKNAME, traderNickname),
+                        user.role.in(Role.TRADER, Role.TRADER_ADMIN));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/investmetic/domain/user/service/UserService.java
+++ b/src/main/java/com/investmetic/domain/user/service/UserService.java
@@ -3,7 +3,6 @@ package com.investmetic.domain.user.service;
 import static com.investmetic.domain.user.dto.object.ColumnCondition.EMAIL;
 import static com.investmetic.domain.user.dto.object.ColumnCondition.NICKNAME;
 import static com.investmetic.domain.user.dto.object.ColumnCondition.PHONE;
-import static com.investmetic.global.util.s3.FilePath.USER_PROFILE;
 
 import com.investmetic.domain.user.dto.object.ColumnCondition;
 import com.investmetic.domain.user.dto.object.TraderListSort;
@@ -45,32 +44,28 @@ public class UserService {
 
     //회원 가입
     @Transactional
-    public String signUp(UserSignUpDto userSignUpDto) {
+    public void signUp(UserSignUpDto userSignUpDto) {
+        try{
+            // 비밀번호 인증코드 검증시 사용하는 메서드 재사용.(Redis에서 삭제)
+            verifyEmailCode(userSignUpDto.getEmail(), userSignUpDto.getCode());
 
-        // imageUrl 초기화.
-        String presignedUrl = null;
+            //중복 검증
+            extracted(userSignUpDto);
 
-        // 비밀번호 인증코드 검증시 사용하는 메서드 재사용.(Redis에서 삭제)
-        verifyEmailCode(userSignUpDto.getEmail(), userSignUpDto.getCode());
 
-        //중복 검증
-        extracted(userSignUpDto);
+            User createUser = UserSignUpDto.toEntity(userSignUpDto, bCryptPasswordEncoder);
 
-        // 사진 저장시.
-        if (userSignUpDto.getImageMetadata() != null) {
-            presignedUrl = s3FileService.getS3Path(USER_PROFILE, userSignUpDto.getImageMetadata().getImageName(),
-                    userSignUpDto.getImageMetadata().getSize());
+            //명시적 세이브...
+            userRepository.save(createUser);
+
+            // 스티비 주소록에 회원 추가.
+            emailService.addSubscriber(createUser);
+
+        } catch (BusinessException e) {
+
+            // 실패시 모두 되돌리고 회원가입 실패 에러 보내주기.(모두 초기화)
+            throw new BusinessException(ErrorCode.SIGN_UP_FAILED);
         }
-
-        User createUser = UserSignUpDto.toEntity(userSignUpDto, presignedUrl, bCryptPasswordEncoder);
-
-        //명시적 세이브...
-        userRepository.save(createUser);
-
-        // 스티비 주소록에 회원 추가.
-        emailService.addSubscriber(createUser);
-
-        return presignedUrl == null ? null : s3FileService.getPreSignedUrl(presignedUrl);
     }
 
 
@@ -152,11 +147,6 @@ public class UserService {
     public PageResponseDto<TraderProfileDto> getTraderList(TraderListSort sort, String keyword, Pageable pageable) {
 
         Page<TraderProfileDto> page = userRepository.getTraderListPage(sort, keyword, pageable);
-
-        // 조회된 트레이더가 없을 때
-        if (page.getContent().isEmpty()) {
-            throw new BusinessException(ErrorCode.TRADER_LIST_RETRIEVAL_FAILED);
-        }
 
         return new PageResponseDto<>(page);
     }

--- a/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/TraderListRepositoryTest.java
@@ -10,7 +10,6 @@ import com.investmetic.domain.strategy.model.entity.Strategy;
 import com.investmetic.domain.strategy.model.entity.TradeType;
 import com.investmetic.domain.strategy.repository.StrategyRepository;
 import com.investmetic.domain.strategy.repository.TradeTypeRepository;
-import com.investmetic.domain.subscription.repository.SubscriptionRepository;
 import com.investmetic.domain.user.dto.object.TraderListSort;
 import com.investmetic.domain.user.dto.response.TraderProfileDto;
 import com.investmetic.domain.user.model.Role;
@@ -19,8 +18,7 @@ import com.investmetic.domain.user.model.entity.User;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -44,14 +42,12 @@ class TraderListRepositoryTest {
     private UserRepository userRepository;
     @Autowired
     private StrategyRepository strategyRepository;
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
 
     @Autowired
     private TradeTypeRepository tradeTypeRepository;
 
     // 트레이더 생성.... 더 자세하게 보려면 데이터가 필요하겠네요.
-    @BeforeAll
+    @BeforeEach
     void createUsers50() {
         Strategy strategy1 = null;
         Strategy strategy2 = null;
@@ -69,7 +65,7 @@ class TraderListRepositoryTest {
                     .email("jlwoo0925" + i + "@gmail.com")
                     .password("asdf" + i)
                     .imageUrl("jrw_projectS3/profile/정룡우.img")
-                    .phone("010123456" + dc.format(i))
+                    .phone("010789789" + dc.format(i))
                     .birthDate("000925")
                     .ipAddress("127.0.0.1")
                     .infoAgreement(Boolean.FALSE)
@@ -104,15 +100,6 @@ class TraderListRepositoryTest {
                 strategyRepository.save(strategy1);
             }
         }
-    }
-
-    @AfterAll
-    void deleteAll() {
-        //constraint -> 연관 관계 순서대로
-        subscriptionRepository.deleteAll();
-        strategyRepository.deleteAll();
-        tradeTypeRepository.deleteAll();
-        userRepository.deleteAll();
     }
 
 
@@ -179,8 +166,6 @@ class TraderListRepositoryTest {
                 // 현재 순서의 트레이너 전략수 대입.
                 bigger = traderProfileDto.getStrategyCount();
             }
-            System.out.println(page.getContent().size());
-
             if (i == page.getTotalPages()) {
                 break;
             }
@@ -211,6 +196,9 @@ class TraderListRepositoryTest {
         for (int i = 1; i <= page.getTotalPages(); i++) {
 
             for (TraderProfileDto traderProfileDto : page.getContent()) {
+                System.out.println(traderProfileDto);
+
+
 
                 // 앞순서의 트레이너의 구독자 수보다 작거나 같아야함.
                 assertThat(traderProfileDto.getTotalSubCount()).isLessThanOrEqualTo(bigger);
@@ -229,7 +217,7 @@ class TraderListRepositoryTest {
 
             // 페이지 증가시키면서 확인.
             Pageable nextPage = PageRequest.of(i, pagesize);
-            page = userRepository.getTraderListPage(sort, null, nextPage);
+            page = userRepository.getTraderListPage(sort, keyword, nextPage);
         }
     }
 

--- a/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/TraderListTest.java
@@ -1,14 +1,11 @@
 package com.investmetic.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.investmetic.domain.user.dto.object.TraderListSort;
 import com.investmetic.domain.user.dto.response.TraderProfileDto;
 import com.investmetic.domain.user.repository.UserRepository;
-import com.investmetic.global.exception.BusinessException;
-import com.investmetic.global.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -49,28 +46,6 @@ class TraderListTest {
 
         // when, then 아무런 에러도 없어야함.
         assertThatCode(() -> userRepository.getTraderListPage(sort, keyword, pageable)).doesNotThrowAnyException();
-
-
-    }
-
-    @Test
-    @DisplayName("트레이더 조회 목록 size가 0일때.")
-    void traderListTest2() {
-
-        // given
-        Pageable pageable = PageRequest.of(0, 12);
-        TraderListSort sort = TraderListSort.STRATEGY_TOTAL;
-        String keyword = null;
-
-        List<TraderProfileDto> list = new ArrayList<>();
-
-        // size가 0인 목록 반환
-        when(userRepository.getTraderListPage(sort, keyword, pageable)).thenReturn(new PageImpl<>(list));
-
-        // when, then - throw BusinessException
-        assertThatThrownBy(() -> userService.getTraderList(sort, keyword, pageable)).isInstanceOf(
-                BusinessException.class).hasMessage(ErrorCode.TRADER_LIST_RETRIEVAL_FAILED.getMessage());
-
     }
 
 }

--- a/src/test/java/com/investmetic/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/investmetic/domain/user/service/UserServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.investmetic.domain.user.dto.object.ImageMetadata;
 import com.investmetic.domain.user.dto.request.UserSignUpDto;
 import com.investmetic.domain.user.dto.response.AvaliableDto;
 import com.investmetic.domain.user.dto.response.UserProfileDto;
@@ -83,46 +82,6 @@ class UserServiceTest {
         //redis에서 인증코드가 삭제가 되어야함.
         assertThat(redisUtil.getData(userSignUpDto.getEmail())).isNotPresent();
     }
-
-
-    @Test
-    @DisplayName("회원 가입 이미지 변경")
-    void signUpTest2() {
-
-        // given
-        UserSignUpDto userSignUpDto = UserSignUpDto.builder()
-                .username("testUser")
-                .nickname("testNickname")
-                .phone("01012345678")
-                .birthdate("19900101")
-                .password("password")
-                .email("test@example.com")
-                .role(Role.INVESTOR)
-                .infoAgreement(true)
-                .code("test")
-                .imageMetadata(new ImageMetadata("test.jpg", 10000))
-                .build();
-        // 인증코드 redis에 저장.
-        redisUtil.setDataExpire(userSignUpDto.getEmail(), userSignUpDto.getCode(), 60);
-
-        // when
-        String presignedUrl = userService.signUp(userSignUpDto);
-
-        // then - DB에 사용자 정보가 저장되었는지 확인
-        assertThat(presignedUrl).contains(userSignUpDto.getImageMetadata().getImageName());
-
-        UserProfileDto savedUser = userRepository.findByEmailUserInfo(userSignUpDto.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_INFO_NOT_FOUND));
-        assertEquals(userSignUpDto.getUsername(), savedUser.getUserName());
-        assertEquals(userSignUpDto.getNickname(), savedUser.getNickname());
-        assertEquals(userSignUpDto.getEmail(), savedUser.getEmail());
-        assertEquals(userSignUpDto.getPhone(), savedUser.getPhone());
-        assertEquals(userSignUpDto.getInfoAgreement(), savedUser.getInfoAgreement());
-
-        //redis에서 인증코드가 삭제가 되어야함.
-        assertThat(redisUtil.getData(userSignUpDto.getEmail())).isNotPresent();
-    }
-
 
     @Test
     @DisplayName("닉네임 중복이 있을 때")


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

>  트레이더 목록조회 리스트 오류 개선, 회원가입 프로필 이미지 저장 x

> ## #️⃣연관된 이슈

> #140

## 💡 리뷰어에게 하고 싶은 말

-  디자인상에서 이미지 저장하지않는다고 하셔서 ImageMetaDto 제외하였습니다.
따라서 회원가입 로직에서 PresignedUrl 전송하지 않기로 프론트와 얘기하였습니다.

- UserSignUpDto에서 @NotNull, @Pattern추가하였습니다.
1. 핸드폰 번호 010으로 시작하여 010-***-**** 또는 010-****-****으로만 입력 가능하도록 하였습니다.
2. 생년월일의 경우 19**-01-01 , 20**-12-31로 받게 하였습니다.

- 트레이더 목록에서 Offset 오류가 있었습니다. 

- 트레이더 목록조회 Test코드에서 Keyword검색시 Keyword가 null값으로 들어가는 오류 고쳤습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
