### PR TITLE
Fix/strateies graph #154

### DIFF
--- a/src/main/java/com/investmetic/domain/strategy/dto/ProfitRateChartDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/ProfitRateChartDto.java
@@ -1,6 +1,8 @@
 package com.investmetic.domain.strategy.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,11 +11,12 @@ import lombok.Getter;
 @JsonPropertyOrder({"dates", "profitRates"})
 public class ProfitRateChartDto {
 
-    private List<String> dates; // x축 데이터 ( YYYY-mm-dd)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private List<LocalDate> dates; // x축 데이터 ( YYYY-mm-dd)
     private List<Double> profitRates; // 수익률 리스트
 
     @Builder
-    public ProfitRateChartDto(List<String> dates, List<Double> profitRates) {
+    public ProfitRateChartDto(List<LocalDate> dates, List<Double> profitRates) {
         this.dates = dates;
         this.profitRates = profitRates;
     }

--- a/src/main/java/com/investmetic/domain/strategy/dto/ProfitRateData.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/ProfitRateData.java
@@ -1,6 +1,5 @@
-package com.investmetic.domain.strategy.dto.response;
+package com.investmetic.domain.strategy.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +9,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class ProfitRateData {
-    @JsonIgnore
     private final Long strategyId;         // 전략 ID
     private final LocalDate dailyDate;        // 날짜 (YYYY-MM-DD 형식)
     private final Double cumulativeProfitLossRate; // 누적 손익률

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/AdminStrategyResponseDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/AdminStrategyResponseDto.java
@@ -1,13 +1,9 @@
 package com.investmetic.domain.strategy.dto.response;
 
-import com.investmetic.domain.strategy.dto.ProfitRateChartDto;
 import com.investmetic.domain.strategy.model.IsApproved;
 import com.investmetic.domain.strategy.model.IsPublic;
-import com.investmetic.domain.strategy.model.entity.Strategy;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.List;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/investmetic/domain/strategy/dto/response/ProfitRateData.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/ProfitRateData.java
@@ -1,0 +1,17 @@
+package com.investmetic.domain.strategy.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ProfitRateData {
+    @JsonIgnore
+    private final Long strategyId;         // 전략 ID
+    private final LocalDate dailyDate;        // 날짜 (YYYY-MM-DD 형식)
+    private final Double cumulativeProfitLossRate; // 누적 손익률
+}

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepository.java
@@ -1,11 +1,28 @@
 package com.investmetic.domain.strategy.repository;
 
-import com.investmetic.domain.strategy.dto.response.AdminStrategyResponseDto;
 import com.investmetic.domain.strategy.model.entity.Strategy;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StrategyRepository extends JpaRepository<Strategy, Long>, StrategyRepositoryCustom {
     Boolean existsByStrategyId(Long StrategyId);
+
+    @Query(value = """
+            SELECT strategy_id, daily_date, cumulative_profit_loss_rate
+            FROM (
+                SELECT
+                    strategy_id,
+                    daily_date,
+                    cumulative_profit_loss_rate,
+                    ROW_NUMBER() OVER (PARTITION BY strategy_id ORDER BY daily_date DESC) AS row_num
+                FROM daily_analysis
+                WHERE strategy_id IN (:strategyIds)
+            ) AS ranked
+            WHERE row_num <= 20
+            ORDER BY strategy_id ASC, daily_date ASC;
+            """,
+            nativeQuery = true)
+    List<Object[]> findTop20ProfitRatesByStrategyIds(@Param("strategyIds") List<Long> strategyIds);
 }

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepositoryCustom.java
@@ -9,7 +9,6 @@ import com.investmetic.domain.strategy.dto.response.TopRankingStrategyResponseDt
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;
 import com.investmetic.domain.strategy.dto.response.common.StrategySimpleResponse;
 import com.investmetic.domain.strategy.model.IsApproved;
-import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import java.util.List;
 import java.util.Map;
@@ -22,8 +21,6 @@ public interface StrategyRepositoryCustom {
     MyStrategyDetailResponse findMyStrategyDetail(Long strategyId);
 
     Map<Long, StockTypeInfo> findStockTypeInfoMap(List<Long> strategyIdS);
-
-    Map<Long, List<Tuple>> findProfitRateDataMap(List<Long> strategyIdS);
 
     Map<Long, Boolean> findBySubscriptionMap(Long userId, List<Long> strategyIdS);
 

--- a/src/main/java/com/investmetic/domain/strategy/service/StrategyListingService.java
+++ b/src/main/java/com/investmetic/domain/strategy/service/StrategyListingService.java
@@ -5,7 +5,7 @@ import static java.util.stream.Collectors.toList;
 import com.investmetic.domain.strategy.dto.ProfitRateChartDto;
 import com.investmetic.domain.strategy.dto.StockTypeInfo;
 import com.investmetic.domain.strategy.dto.request.SearchRequest;
-import com.investmetic.domain.strategy.dto.response.ProfitRateData;
+import com.investmetic.domain.strategy.dto.ProfitRateData;
 import com.investmetic.domain.strategy.dto.response.SearchInfoResponseDto;
 import com.investmetic.domain.strategy.dto.response.common.BaseStrategyResponse;
 import com.investmetic.domain.strategy.dto.response.common.MyStrategySimpleResponse;


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 전략목록 수익률그래프 20개씩 안나오는 문제 해결


> ## #️⃣연관된 이슈

> ex) #154 

## 💡 리뷰어에게 하고 싶은 말
- 전략목록 수익률그래프 20개씩 안나오는 문제 해결 ( querydsl -> 네이티브쿼리로 변경)
   - JPQL limit 적용이 안되는 문제였음 
- 코드 맘에 안들어 죽겠지만 기능은 동작하니,, 추후 리팩토링 할수있으면 하겠습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
